### PR TITLE
Add ize build on push (CORE-179)

### DIFF
--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -24,3 +24,4 @@ jobs:
       with:
         name: ${{ runner.os }}
         path: ize
+


### PR DESCRIPTION
#### What's new:

 - Added ize build with github workflow and push builds as artefacts

#### Testing done:

<img width="1661" alt="screenshot 2021-10-18 at 18 41 33" src="https://user-images.githubusercontent.com/24703846/137764483-e2cd6e1c-12a0-4217-904a-7199ea37912e.png">
