### PR TITLE
Add ize build on release (CORE-179)

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -1,0 +1,28 @@
+name: "Build IZE on release"
+on:
+  release:
+    types: [created]
+jobs:
+  Build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+       go-version: 1.16.x
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Build
+      run: go build -o ./ize ./cmd
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./ize
+        asset_name: ${{ runner.os }}
+        asset_content_type: application/zip


### PR DESCRIPTION
### What's new: 

 - Added ize build on manual release
 - Added builded ize binaries upload to release


### Testing done:

#### GitHub workflow started on manual release:

<img width="952" alt="screenshot 2021-10-19 at 23 09 50" src="https://user-images.githubusercontent.com/24703846/137986044-0195bf16-ced3-48fc-a125-71614d822991.png">

#### GitHub workflow run was successful:

<img width="1680" alt="screenshot 2021-10-19 at 23 27 03" src="https://user-images.githubusercontent.com/24703846/137986066-42cf8ea7-db72-4841-a102-8e771d1276a5.png">

#### Results. IZE binaries was uploaded to the release:

<img width="1672" alt="screenshot 2021-10-19 at 23 27 37" src="https://user-images.githubusercontent.com/24703846/137986093-06cb2da4-5e31-4d68-876a-d0e013994315.png">
