### PR TITLE
TOOLS-72 TOOLS-75 external tools validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hazelops/ize
 go 1.16
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/aws/aws-sdk-go v1.40.56
 	github.com/containerd/containerd v1.5.4 // indirect
 	github.com/docker/docker v20.10.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/MarvinJWendt/testza v0.1.0/go.mod h1:7AxNvlfeHP7Z/hDQ5JtE3OKYT3XFUeLC
 github.com/MarvinJWendt/testza v0.2.1/go.mod h1:God7bhG8n6uQxwdScay+gjm9/LnO4D3kkcZX4hv9Rp8=
 github.com/MarvinJWendt/testza v0.2.8 h1:wADjxMxaIeasMStYq3AFsVyKR0B+1nkFfiRfnz2NEtI=
 github.com/MarvinJWendt/testza v0.2.8/go.mod h1:nwIcjmr0Zz+Rcwfh3/4UhBp7ePKVhuBExvZqnKYWlII=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -172,6 +172,11 @@ func (cc *izeBuilderCommon) Init() error {
 	viper.SetDefault("TF_LOG", fmt.Sprintf(""))
 	viper.SetDefault("TF_LOG_PATH", fmt.Sprintf("%v/tflog.txt", viper.Get("ENV_DIR")))
 
+	//Check Docker and SSM Agent
+	err = CheckCommand("docker", []string{"info"})
+	if err != nil {
+		return errors.New("docker is not running or is not installed")
+	}
 	return nil
 }
 

--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/hazelops/ize/internal/config"
 	"github.com/hazelops/ize/pkg/logger"
 	"github.com/pterm/pterm"
@@ -174,41 +176,80 @@ func (cc *izeBuilderCommon) Init() error {
 	viper.SetDefault("TF_LOG_PATH", fmt.Sprintf("%v/tflog.txt", viper.Get("ENV_DIR")))
 
 	//Check Docker and SSM Agent
-	err = CheckCommand("docker", []string{"info"})
+	_, err = CheckCommand("docker", []string{"info"})
 	if err != nil {
-		return errors.New("docker is not running or is not installed")
+		return errors.New("docker is not running or is not installed (visit https://www.docker.com/get-started)")
 	}
 
-	err = CheckCommand("session-manager-plugin", []string{})
+	_, err = CheckCommand("session-manager-plugin", []string{})
 	if err != nil {
-		pterm.Warning.Println("SSM Agent is not installed. Trying to install SSM Agent")
+		pterm.Warning.Println("SSM Agent plugin is not installed. Trying to install SSM Agent plugin")
 
-		pterm.DefaultSection.Println("Installing SSM Agent")
+		var pyVersion string
 
-		err := DownloadSSMAgent()
+		pyVersion, err = CheckCommand("python3", []string{"--version"})
 		if err != nil {
-			return fmt.Errorf("download SSM Agent error: %v", err)
+			pyVersion, err = CheckCommand("python", []string{"--version"})
+			if err != nil {
+				return errors.New("python is not installed")
+			}
+
+			c, err := semver.NewConstraint("<= 2.6.5")
+			if err != nil {
+				return err
+			}
+
+			v, err := semver.NewVersion(strings.TrimSpace(strings.Split(pyVersion, " ")[1]))
+			if err != nil {
+				return err
+			}
+
+			if c.Check(v) {
+				return fmt.Errorf("python version %s below required %s", v.String(), "2.6.5")
+			}
+			return errors.New("python is not installed")
 		}
 
-		pterm.Success.Println("Downloading SSM Agent")
+		c, err := semver.NewConstraint("<= 3.3.0")
+		if err != nil {
+			return err
+		}
+
+		v, err := semver.NewVersion(strings.TrimSpace(strings.Split(pyVersion, " ")[1]))
+		if err != nil {
+			return err
+		}
+
+		if c.Check(v) {
+			return fmt.Errorf("python version %s below required %s", v.String(), "3.3.0")
+		}
+
+		pterm.DefaultSection.Println("Installing SSM Agent plugin")
+
+		err = DownloadSSMAgentPlugin()
+		if err != nil {
+			return fmt.Errorf("download SSM Agent plugin error: %v (visit https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)", err)
+		}
+
+		pterm.Success.Println("Downloading SSM Agent plugin")
 
 		err = InstallSSMAgent()
 		if err != nil {
-			return fmt.Errorf("install SSM Agent error: %v", err)
+			return fmt.Errorf("install SSM Agent plugin error: %v (visit https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)", err)
 		}
 
-		pterm.Success.Println("Installing SSM Agent")
+		pterm.Success.Println("Installing SSM Agent plugin")
 
 		err = CleanupSSMAgent()
 		if err != nil {
-			return fmt.Errorf("cleanup SSM Agent error: %v", err)
+			return fmt.Errorf("cleanup SSM Agent plugin error: %v (visit https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)", err)
 		}
 
-		pterm.Success.Println("Cleanup Session Manager installation package")
+		pterm.Success.Println("Cleanup Session Manager plugin installation package")
 
-		err = CheckCommand("session-manager-plugin", []string{})
+		_, err = CheckCommand("session-manager-plugin", []string{})
 		if err != nil {
-			return err
+			return fmt.Errorf("check SSM Agent plugin error: %v (visit https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)", err)
 		}
 	}
 

--- a/internal/commands/base_init.go
+++ b/internal/commands/base_init.go
@@ -14,7 +14,7 @@ func (c *izeBuilderCommon) initConfig(filename string) (*config.Config, error) {
 	}
 
 	if path == "" {
-		return nil, errors.New("A Waypoint configuration file (waypoint.hcl) is required but wasn't found.")
+		return nil, errors.New("a Ize configuration file (ize.hcl) is required but wasn't found")
 	}
 
 	return c.initConfigLoad(path)
@@ -23,7 +23,7 @@ func (c *izeBuilderCommon) initConfig(filename string) (*config.Config, error) {
 func (c *izeBuilderCommon) initConfigPath(filename string) (string, error) {
 	path, err := config.FindPath(filename)
 	if err != nil {
-		return "", fmt.Errorf("Error looking for a Ize configuration: %s", err)
+		return "", fmt.Errorf("error looking for a Ize configuration: %s", err)
 	}
 
 	return path, nil

--- a/internal/commands/base_init.go
+++ b/internal/commands/base_init.go
@@ -14,7 +14,7 @@ func (c *izeBuilderCommon) initConfig(filename string) (*config.Config, error) {
 	}
 
 	if path == "" {
-		return nil, errors.New("a Ize configuration file (ize.hcl) is required but wasn't found")
+		return nil, errors.New("an Ize configuration file (ize.hcl) is required but wasn't found")
 	}
 
 	return c.initConfigLoad(path)

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -5,3 +5,12 @@ import "github.com/spf13/cobra"
 type cmder interface {
 	getCommand() *cobra.Command
 }
+
+func CheckCommand(command string, subcommand []string) error {
+	err := exec.Command(command, subcommand...).Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -18,13 +18,13 @@ type cmder interface {
 	getCommand() *cobra.Command
 }
 
-func CheckCommand(command string, subcommand []string) error {
-	err := exec.Command(command, subcommand...).Run()
+func CheckCommand(command string, subcommand []string) (string, error) {
+	out, err := exec.Command(command, subcommand...).Output()
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return string(out), nil
 }
 
 const (
@@ -32,7 +32,7 @@ const (
 	ssmMacOsUrl = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip"
 )
 
-func DownloadSSMAgent() error {
+func DownloadSSMAgentPlugin() error {
 	switch goos := runtime.GOOS; goos {
 	case "darwin":
 		client := http.Client{
@@ -124,7 +124,7 @@ func DownloadSSMAgent() error {
 			}
 		}
 	default:
-		return fmt.Errorf("unable to install SSM agent automatically.\nPlease install SSM Agent manually and try again")
+		return fmt.Errorf("unable to install automatically")
 	}
 
 	return nil
@@ -134,9 +134,9 @@ func CleanupSSMAgent() error {
 	command := []string{}
 
 	if runtime.GOOS == "darwin" {
-		command = []string{"rm", "-rf", "sessionmanager-bundle sessionmanager-bundle.zip"}
+		command = []string{"rm", "-f", "sessionmanager-bundle sessionmanager-bundle.zip"}
 	} else if runtime.GOOS == "linux" {
-		command = []string{"rm", "-rf", "session-manager-plugin.rpm"}
+		command = []string{"rm", "-f", "session-manager-plugin.rpm"}
 
 		distrName, err := getLinuxDistoName()
 		if err != nil {

--- a/internal/commands/helpers.go
+++ b/internal/commands/helpers.go
@@ -1,6 +1,18 @@
 package commands
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+)
 
 type cmder interface {
 	getCommand() *cobra.Command
@@ -13,4 +25,182 @@ func CheckCommand(command string, subcommand []string) error {
 	}
 
 	return nil
+}
+
+const (
+	ssmLinuxUrl = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/%s_%s/session-manager-plugin%s"
+	ssmMacOsUrl = "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/mac/sessionmanager-bundle.zip"
+)
+
+func DownloadSSMAgent() error {
+	switch goos := runtime.GOOS; goos {
+	case "darwin":
+		client := http.Client{
+			CheckRedirect: func(r *http.Request, via []*http.Request) error {
+				r.URL.Opaque = r.URL.Path
+				return nil
+			},
+		}
+
+		file, err := os.Create("session-manager-plugin.deb")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		resp, err := client.Get(ssmMacOsUrl)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer resp.Body.Close()
+
+		_, err = io.Copy(file, resp.Body)
+		if err != nil {
+			return err
+		}
+
+		defer file.Close()
+	case "linux":
+		distrName, err := getLinuxDistoName()
+		if err != nil {
+			return err
+		}
+
+		arch := ""
+
+		switch runtime.GOARCH {
+		case "amd64":
+			arch = "64bit"
+		case "386":
+			arch = "32bit"
+		case "arm":
+			arch = "arm32"
+		case "arm64":
+			arch = "arm64"
+		}
+
+		client := http.Client{
+			CheckRedirect: func(r *http.Request, via []*http.Request) error {
+				r.URL.Opaque = r.URL.Path
+				return nil
+			},
+		}
+
+		if distrName == "Ubuntu" || distrName == "Debian" {
+			file, err := os.Create("session-manager-plugin.deb")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := client.Get(fmt.Sprintf(ssmLinuxUrl, "ubuntu", arch, ".deb"))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			defer resp.Body.Close()
+
+			_, err = io.Copy(file, resp.Body)
+			if err != nil {
+				return err
+			}
+
+			defer file.Close()
+		} else {
+			file, err := os.Create("session-manager-plugin.rpm")
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			resp, err := client.Get(fmt.Sprintf(ssmLinuxUrl, "linux", arch, ".rpm"))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			defer resp.Body.Close()
+
+			_, err = io.Copy(file, resp.Body)
+			if err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unable to install SSM agent automatically.\nPlease install SSM Agent manually and try again")
+	}
+
+	return nil
+}
+
+func CleanupSSMAgent() error {
+	command := []string{}
+
+	if runtime.GOOS == "darwin" {
+		command = []string{"rm", "-rf", "sessionmanager-bundle sessionmanager-bundle.zip"}
+	} else if runtime.GOOS == "linux" {
+		command = []string{"rm", "-rf", "session-manager-plugin.rpm"}
+
+		distrName, err := getLinuxDistoName()
+		if err != nil {
+			return err
+		}
+
+		if distrName == "Ubuntu" || distrName == "Debian" {
+			command = []string{"rm", "-rf", "session-manager-plugin.deb"}
+		}
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func InstallSSMAgent() error {
+	command := []string{}
+
+	if runtime.GOOS == "darwin" {
+		command = []string{"sudo", "./sessionmanager-bundle/install", "-i /usr/local/sessionmanagerplugin", "-b", "/usr/local/bin/session-manager-plugin"}
+	} else if runtime.GOOS == "linux" {
+		command = []string{"sudo", "yum", "install", "-y", "-q", "session-manager-plugin.deb"}
+
+		distrName, err := getLinuxDistoName()
+		if err != nil {
+			return err
+		}
+		if distrName == "Ubuntu" || distrName == "Debian" {
+			command = []string{"sudo", "dpkg", "-i", "session-manager-plugin.deb"}
+		}
+	} else {
+		return fmt.Errorf("automatic installation of SSM Agent for your OS is not supported")
+	}
+
+	cmd := exec.Command(command[0], command[1:]...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	pterm.Info.Println(string(out))
+
+	return nil
+}
+
+func getLinuxDistoName() (string, error) {
+	f, err := os.Open("/etc/issue")
+	if err != nil {
+		return "", err
+	}
+
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	disto := strings.Split(string(b), " ")[0]
+
+	return disto, nil
 }

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -1,0 +1,37 @@
+package commands
+
+import "testing"
+
+func TestCheckCommand(t *testing.T) {
+	type args struct {
+		command    string
+		subcommand []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Error case",
+			args: args{
+				command: "error_case",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Success case",
+			args: args{
+				command: "ls",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := CheckCommand(tt.args.command, tt.args.subcommand); (err != nil) != tt.wantErr {
+				t.Errorf("CheckCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/commands/terraform.go
+++ b/internal/commands/terraform.go
@@ -42,8 +42,6 @@ func (b *commandsBuilder) newTerraformCmd() *terraformCmd {
 				return err
 			}
 
-			pterm.DefaultSection.Println("Generating terraform files")
-
 			opts := TerraformRunOption{
 				ContainerName: "terraform-init",
 				Cmd:           []string{"init", "-input=true"},
@@ -70,7 +68,6 @@ func (b *commandsBuilder) newTerraformCmd() *terraformCmd {
 		command executes the actions proposed in a Terraform plan`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cc.Init()
-
 			if err != nil {
 				return err
 			}
@@ -102,7 +99,6 @@ func (b *commandsBuilder) newTerraformCmd() *terraformCmd {
 		The terraform plan command creates an execution plan.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cc.Init()
-
 			if err != nil {
 				return err
 			}
@@ -133,7 +129,6 @@ func (b *commandsBuilder) newTerraformCmd() *terraformCmd {
 		Long:  `This command run terraform destroy command.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cc.Init()
-
 			if err != nil {
 				return err
 			}
@@ -246,7 +241,7 @@ func runTerraform(cc *terraformCmd, opts TerraformRunOption) error {
 	pterm.Success.Printfln("Creating terraform container from image %v:%v", imageName, imageTag)
 
 	if err := cli.ContainerStart(context.Background(), cont.ID, types.ContainerStartOptions{}); err != nil {
-		pterm.Error.Printfln("Terraform container started:", cont.ID)
+		pterm.Error.Println("Terraform container started:", cont.ID)
 		return err
 	}
 


### PR DESCRIPTION
This commits adds:
- external tools validation 
- installing SSM Agent automatically 

Example: 

Windows 11 SSM Agent
![image](https://user-images.githubusercontent.com/47272597/139033249-5b3de728-d2de-4d1d-a4f3-7deecf643f8e.png)

Ubuntu (wsl2) SSM Agent
[![asciicast](https://asciinema.org/a/6LgGPojgEgBlNsAykFwnoUvBt.svg)](https://asciinema.org/a/6LgGPojgEgBlNsAykFwnoUvBt)

Ubuntu (wsl2) Docker
[![asciicast](https://asciinema.org/a/8IozlqwC52HZ3Nt8qWBhlwrFO.svg)](https://asciinema.org/a/8IozlqwC52HZ3Nt8qWBhlwrFO)

Windows 11 Docker
![image](https://user-images.githubusercontent.com/47272597/139034023-ba8e5ee1-f1ed-4920-bf7c-1a113a55f073.png)

### Not tested on MasOS