### PR TITLE
Add ize installation info to MacOS via Homebrew (TOOLS-78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ize deploy infra
 ize destroy infra
 ```
 
-## Ize installation via homebrew(MacOS only):
+## Ize installation via homebrew (MacOS only):
 
 ##### 1. Install [Homebrew](https://brew.sh/)
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@ ize secret get
 ize deploy infra
 ize destroy infra
 ```
+
+## Ize installation via homebrew(MacOS only):
+
+##### 1. Install [Homebrew](https://brew.sh/)
+
+##### 2. Run the following commands:
+  
+  2.1 `brew tap hazelops/ize`
+   
+  2.2 `brew install ize`
+
+#### 3. Now you can run `ize` from command shell by typing `ize` in console.


### PR DESCRIPTION
#### What's new:

 - Added ize installation info via hombrew