### PR TITLE
Add GoReleaser to github workflow (TOOLS-85)

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -2,12 +2,10 @@ name: "Build IZE on release"
 on:
   release:
     types: [created]
+  workflow_dispatch:
 jobs:
   Build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -15,14 +13,14 @@ jobs:
        go-version: 1.16.x
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Build
-      run: go build -o ./ize ./cmd
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
+      with:
+        fetch-depth: 0
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v2
+      with:
+        # either 'goreleaser' (default) or 'goreleaser-pro'
+        distribution: goreleaser
+        version: latest
+        args: release -f .goreleaser.yml --rm-dist
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./ize
-        asset_name: ${{ runner.os }}
-        asset_content_type: application/zip

--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -2,7 +2,6 @@ name: "Build IZE on release"
 on:
   release:
     types: [created]
-  workflow_dispatch:
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,13 @@
+project_name: ize
+builds:
+  - env: [CGO_ENABLED=0]
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    id: "ize"
+    dir: .
+    main: ./cmd


### PR DESCRIPTION
#### What's new:

- Replaced go builder with GoReleaser on release


#### Testing done:

<img width="1490" alt="screenshot 2021-11-02 at 17 29 29" src="https://user-images.githubusercontent.com/24703846/139874023-c8627ca8-47d9-408a-9cbd-292ba66104d5.png">
