### PR TITLE
TOOLS-92 add version flag

### DIFF
--- a/internal/commands/base.go
+++ b/internal/commands/base.go
@@ -67,8 +67,9 @@ func (b *commandsBuilder) newIzeCmd() *izeCmd {
 	cc := &izeCmd{}
 
 	cc.baseBuilderCmd = b.newBuilderCmd(&cobra.Command{
-		Use:   "ize",
-		Short: "A brief description of your application",
+		Use:     "ize",
+		Version: GetVersionNumber(),
+		Short:   "A brief description of your application",
 		Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
 

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,0 +1,7 @@
+package commands
+
+var Version = "development"
+
+func GetVersionNumber() string {
+	return Version
+}


### PR DESCRIPTION
This commit adds a flag for print IZE version
![image](https://user-images.githubusercontent.com/47272597/140010569-e86fa86e-3aeb-46b1-bccc-e990d1e27424.png)
