### PR TITLE
Add deb package creation, upload to fury.io and Ubuntu apt installation documentation (TOOLS-84)

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -34,3 +34,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        FURY_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ nfpms:
     homepage: https://ize.sh
     maintainer: Ize development team <ize@hazelops.com>
     description: IZE is an opinionated infrastructure wrapper that allows to use multiple tools in one infra
-    license: MIT
+    license: Apache 2.0
 
 publishers:
   - name: fury.io

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,6 +56,7 @@ nfpms:
     file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - deb
+      - rpm
     vendor: HazelOps
     homepage: https://ize.sh
     maintainer: Ize development team <ize@hazelops.com>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,3 +40,33 @@ brews:
     # Custom install script for brew.
     install: |
       bin.install "ize"
+nfpms:
+  # note that this is an array of nfpm configs
+  -
+    # ID of the nfpm config, must be unique.
+    # Defaults to "default".
+    id: ize
+
+    # Name of the package.
+    # Defaults to `ProjectName`.
+#    package_name: ize
+
+    # You can change the file name of the package.
+    # Default: `{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}`
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - deb
+    vendor: HazelOps
+    homepage: https://ize.sh
+    maintainer: Ize development team <ize@hazelops.com>
+    description: IZE is an opinionated infrastructure wrapper that allows to use multiple tools in one infra
+    license: MIT
+
+publishers:
+  - name: fury.io
+    # by specifying `packages` id here goreleaser will only use this publisher
+    # with artifacts identified by this id
+    ids:
+      - ize
+    dir: "{{ dir .ArtifactPath }}"
+    cmd: curl -F package=@{{ .ArtifactName }} https://{{ .Env.FURY_TOKEN }}@push.fury.io/hazelops/

--- a/README.md
+++ b/README.md
@@ -61,13 +61,11 @@ ize destroy infra
 
 ## Ize installation via public apt repository URL (Ubuntu):
 
-##### 1. To enable, create the following file:
+##### 1. To add public apt repository run:
 
- `/etc/apt/sources.list.d/fury.list` with the following content:
-
- ```fury.list  
- deb [trusted=yes] https://apt.fury.io/hazelops/ /
- ```
+ ```shell
+sudo echo "deb [trusted=yes] https://apt.fury.io/hazelops/ /" > /etc/apt/sources.list.d/fury.list
+```
 
 ##### 2. After this, you should update information. Run:
 ```shell

--- a/README.md
+++ b/README.md
@@ -59,3 +59,35 @@ ize destroy infra
   4.2 Update version in brew repo: `brew tap hazelops/ize`
   4.3 Install `ize`: `brew install ize`
 
+## Ize installation via public apt repository URL (Ubuntu):
+
+##### 1. To enable, create the following file:
+
+ `/etc/apt/sources.list.d/fury.list` with the following content:
+
+ ```fury.list  
+ deb [trusted=yes] https://apt.fury.io/hazelops/ /
+ ```
+
+##### 2. After this, you should update information. Run:
+```shell
+apt-get update
+```
+
+##### 3. To install the latest version of `ize` app, you should run:
+
+```shell
+apt-get install ize 
+```
+
+##### 4. If you wish to install certain version of the `ize` you should add version like this:
+
+ ```shell
+ apt-get install ize=<version>
+ ```
+
+##### 6. To remove `ize` app - run this command:
+
+```shell
+apt-get purge ize
+```

--- a/README.md
+++ b/README.md
@@ -5,19 +5,88 @@ It combines build and deploy workflows in one.
 
 This tool is using configuration file that describes the workflows.
 
-## Quickstart
-- GO version should be 1.16+
-- `GOPATH` environment variable is set to `~/go` 
+## Installation:
 
-### Ize initialization
+### To install the latest version of Ize via homebrew (MacOS only):
+
+##### 1. Install [Homebrew](https://brew.sh/)
+
+##### 2. Run the following commands:
+
+2.1 `brew tap hazelops/ize`
+
+2.2 `brew install ize`
+
+#### 3. Now you can run `ize` from command shell by typing `ize` in console.
+
+#### 4. To update `ize`:
+4.1 Uninstall previous version (`brew uninstall ize`)
+4.2 Update version in brew repo: `brew tap hazelops/ize`
+4.3 Install `ize`: `brew install ize`
+
+### Ize installation via public apt repository URL (Ubuntu):
+
+##### 1. To add public apt repository run:
+
+ ```shell
+echo "deb [trusted=yes] https://apt.fury.io/hazelops/ /" | sudo tee /etc/apt/sources.list.d/fury.list
+```
+
+##### 2. After this, you should update information. Run:
+```shell
+sudo apt-get update
+```
+
+##### 3. To install the latest version of `ize` app, you should run:
+
+```shell
+sudo apt-get install ize 
+```
+
+##### 4. If you wish to install certain version of the `ize` you should add version like this:
+
+ ```shell
+sudo apt-get install ize=<version>
+ ```
+
+##### 6. To remove `ize` app - run this command:
+
+```shell
+sudo apt-get purge ize
+```
+
+### Ize installation from source:
+
+#### Prerequisites:
+
+- GO version should be 1.16+
+- `GOPATH` environment variable is set to `~/go`
+
+To install Ize from source download code or clone it from this repo. After this you should run:
+
 ```shell
 go mod download
 make install
 ```
 
-(acts as an ideation doc, stuff is not working)
-### Application Lifecycle
+### To use Ize, you should create configuration file like this (ize.hcl):
 
+```hcl
+env               = "dev"
+terraform_version = "0.13.5"
+aws_config        = "company-dev"
+aws_profile       = "company-dev"
+aws_region        = "us-east-1"
+namespace         = "company"
+```
+
+
+
+
+
+
+### Application Lifecycle
+(acts as an ideation doc, stuff is not working)
 ```shell
 ize build <goblin>
 ize deploy <goblin>
@@ -42,50 +111,3 @@ ize deploy infra
 ize destroy infra
 ```
 
-## Ize installation via homebrew (MacOS only):
-
-##### 1. Install [Homebrew](https://brew.sh/)
-
-##### 2. Run the following commands:
-  
-  2.1 `brew tap hazelops/ize`
-   
-  2.2 `brew install ize`
-
-#### 3. Now you can run `ize` from command shell by typing `ize` in console.
-
-#### 4. To update `ize`:
-  4.1 Uninstall previous version (`brew uninstall ize`)
-  4.2 Update version in brew repo: `brew tap hazelops/ize`
-  4.3 Install `ize`: `brew install ize`
-
-## Ize installation via public apt repository URL (Ubuntu):
-
-##### 1. To add public apt repository run:
-
- ```shell
-sudo echo "deb [trusted=yes] https://apt.fury.io/hazelops/ /" > /etc/apt/sources.list.d/fury.list
-```
-
-##### 2. After this, you should update information. Run:
-```shell
-apt-get update
-```
-
-##### 3. To install the latest version of `ize` app, you should run:
-
-```shell
-apt-get install ize 
-```
-
-##### 4. If you wish to install certain version of the `ize` you should add version like this:
-
- ```shell
- apt-get install ize=<version>
- ```
-
-##### 6. To remove `ize` app - run this command:
-
-```shell
-apt-get purge ize
-```


### PR DESCRIPTION
#### What's new:

 - Added deb package of ize creation to GoReleaser workflow
 - Added upload of deb package to Gemfury.io repo (https://apt.fury.io/hazelops/)
 - Added instruction of how to install ize on linux using public repo

#### Testing done:

Installation from repo:

<img width="533" alt="screenshot 2021-11-04 at 18 34 26" src="https://user-images.githubusercontent.com/24703846/140415531-2dd4e0fc-6a7a-4300-bf93-520c377b4b42.png">

Upgrade from repo:

<img width="523" alt="screenshot 2021-11-04 at 19 24 36" src="https://user-images.githubusercontent.com/24703846/140415604-051274fc-e2ba-479c-b22c-19acfef0243d.png">

