### PR TITLE
Main environment parameters read from conventional env vars (TOOLS-186)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -191,7 +191,6 @@ func InitializeConfig() error {
 	viper.SetDefault("TF_LOG_PATH", fmt.Sprintf("%v/tflog.txt", viper.Get("ENV_DIR")))
 	viper.SetDefault("TAG", string(tag))
 
-
 	return nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,11 @@ func InitializeConfig() error {
 		return err
 	}
 
+	viper.SetDefault("ENV", os.Getenv("ENV"))
+	viper.SetDefault("AWS_PROFILE", os.Getenv("AWS_PROFILE"))
+	viper.SetDefault("AWS_REGION", os.Getenv("AWS_REGION"))
+	viper.SetDefault("NAMESPACE", os.Getenv("NAMESPACE"))
+
 	if viper.GetString("config-file") != "" {
 		_, err := initConfig(viper.GetString("config-file"))
 		if err != nil {
@@ -129,7 +134,7 @@ func InitializeConfig() error {
 	if len(viper.GetString("aws-profile")) == 0 {
 		viper.Set("aws-profile", viper.GetString("aws_profile"))
 		if len(viper.GetString("aws-profile")) == 0 {
-			return fmt.Errorf("AWS profile must be specified using flags or config file")
+			return fmt.Errorf("AWS profile must be specified using flags, config file or env var")
 		}
 	}
 
@@ -185,6 +190,7 @@ func InitializeConfig() error {
 	viper.SetDefault("TF_LOG", fmt.Sprintf(""))
 	viper.SetDefault("TF_LOG_PATH", fmt.Sprintf("%v/tflog.txt", viper.Get("ENV_DIR")))
 	viper.SetDefault("TAG", string(tag))
+
 
 	return nil
 }


### PR DESCRIPTION
Add ability to read the following env vars:
- ENV
- AWS_PROFILE
- AWS_REGION
- NAMESPACE
In addition to `IZE_*` prefixed-ones

[![asciicast](https://asciinema.org/a/YMnmXJyZWPapavZOb8hvufFS0.svg)](https://asciinema.org/a/YMnmXJyZWPapavZOb8hvufFS0)