### PR TITLE
TOOLS-212 fix ize tunnel handle args

### DIFF
--- a/internal/commands/tunnel/tunnel.go
+++ b/internal/commands/tunnel/tunnel.go
@@ -42,6 +42,7 @@ func NewCmdTunnel() *cobra.Command {
 		Use:              "tunnel",
 		Short:            "tunnel management",
 		Long:             "Tunnel management.",
+		Args:             cobra.NoArgs,
 		TraverseChildren: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := o.Complete(cmd, args)


### PR DESCRIPTION
## Changelog: 
- fix ize tunnel handle args

## Test:
[![asciicast](https://asciinema.org/a/AFk2XS1wqMzw6SNIbRi2jPTLr.svg)](https://asciinema.org/a/AFk2XS1wqMzw6SNIbRi2jPTLr)