### PR TITLE
Change Docs path (TOOLS-184)

### DIFF
--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -39,7 +39,7 @@ func newApp() (*cobra.Command, error) {
 		Use: "ize",
 		Long: fmt.Sprintf("%s\n%s\n%s",
 			pterm.White(pterm.Bold.Sprint("Welcome to IZE")),
-			pterm.Sprintf("%s %s", pterm.Blue("Docs:"), "https://ize.sh"),
+			pterm.Sprintf("%s %s", pterm.Blue("Docs:"), "https://ize.sh/docs"),
 			pterm.Sprintf("%s %s", pterm.Green("Version:"), Version),
 		),
 		TraverseChildren: true,


### PR DESCRIPTION
#### What's new: 

 - Changed path to docs in the welcome message

#### Testing done:
<img width="318" alt="screenshot 2022-01-28 at 13 01 40" src="https://user-images.githubusercontent.com/24703846/151527137-579eb13d-c6ba-4636-ba49-8ee03ee0fbfa.png">
