### PR TITLE
Add md to html converter (TOOLS-183)

### DIFF
--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -41,14 +41,27 @@ jobs:
         mkdir -p commands
         go run ./cmd gendoc
 
+    - name: convert MD to HTML
+      uses: baileyjm02/markdown-to-pdf@v1
+      with:
+        input_dir: commands
+        output_dir: docs
+        # Default is true, can set to false to only get PDF files
+        build_html: true
+
+    - name: remove pdfs #This needs because action creates PDF by default
+      run: |
+        cd docs
+        sudo rm *.pdf
+
     - name: Pushes ize commands to ize.sh
       uses: dmnemec/copy_file_to_another_repo_action@main
       env:
         API_TOKEN_GITHUB: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
       with:
-        source_file: 'commands'
+        source_file: 'docs'
         destination_repo: 'hazelops/ize.sh'
-        destination_folder: 'content'
+#        destination_folder: 'content'
         user_email: 'ize@hazelops.com'
         user_name: 'ize'
         commit_message: 'Add commands from Ize'

--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -64,7 +64,7 @@ jobs:
       with:
         source_file: 'docs'
         destination_repo: 'hazelops/ize.sh'
-#        destination_folder: 'content'
+        destination_folder: 'public'
         user_email: 'ize@hazelops.com'
         user_name: 'ize'
         commit_message: 'Add commands from Ize'

--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -49,10 +49,13 @@ jobs:
         # Default is true, can set to false to only get PDF files
         build_html: true
 
-    - name: remove pdfs #This needs because action creates PDF by default
+    - name: remove pdfs and rename links #This needs because action creates PDF by default
       run: |
         cd docs
         sudo rm *.pdf
+        sudo mv ize.html index.html
+        sudo sed -i 's/.md/.html/g' *
+        sudo sed -i 's/ize.html/index.html/g' *
 
     - name: Pushes ize commands to ize.sh
       uses: dmnemec/copy_file_to_another_repo_action@main


### PR DESCRIPTION
#### What's new:

 - Added markdown to html convertor (uses https://github.com/marketplace/actions/markdown-to-pdf-and-html)
   (Styles coud be added through css file)
 - Changed destination of document files to `docs` in ize.sh repo
 
#### Testing done: 
<img width="889" alt="screenshot 2022-02-10 at 20 13 00" src="https://user-images.githubusercontent.com/24703846/153460280-aaf207d2-332a-46db-a19d-365fcbd906d0.png">
