### PR TITLE
IZE-241 fix tests for console commands

### DIFF
--- a/internal/commands/console/console_test.go
+++ b/internal/commands/console/console_test.go
@@ -27,9 +27,9 @@ func TestRunConsole(t *testing.T) {
 			},
 		},
 		{
-			name:        "service not found",
+			name:        "app not found",
 			expectedErr: "ServiceNotFoundException: Service not found.",
-			args:        []string{"unknow_service"},
+			args:        []string{"unknow_app"},
 			flags: map[string]string{
 				"aws_profile": "default",
 				"aws_region":  "us-east-1",
@@ -58,18 +58,8 @@ func TestRunConsole(t *testing.T) {
 			},
 		},
 		{
-			name:        "service name not set",
-			expectedErr: "can't validate: service name must be specified\n",
-			args:        []string{""},
-			flags: map[string]string{
-				"aws_region": "us-east-1",
-				"env":        "dev",
-				"namespace":  "nutcorp",
-			},
-		},
-		{
-			name:        "service name not set",
-			expectedErr: "can't validate: service name must be specified\n",
+			name:        "app name not set",
+			expectedErr: "can't validate: app name must be specified\n",
 			args:        []string{""},
 			flags: map[string]string{
 				"aws_region": "us-east-1",


### PR DESCRIPTION
## Changelog:
- fix tests for console commands

## Test:
```
go tool cover -func cover.out                       
github.com/hazelops/ize/internal/commands/console/console.go:22:        NewConsoleFlags 100.0%
github.com/hazelops/ize/internal/commands/console/console.go:26:        NewCmdConsole   93.3%
github.com/hazelops/ize/internal/commands/console/console.go:60:        Complete        87.5%
github.com/hazelops/ize/internal/commands/console/console.go:77:        Validate        100.0%
github.com/hazelops/ize/internal/commands/console/console.go:92:        Run             88.9%
total:                                                                  (statements)    91.4%
```