### PR TITLE
IZE-273 set namespace as required

### DIFF
--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -90,10 +90,10 @@ func newApp(ui terminal.UI) (*cobra.Command, error) {
 
 	rootCmd.PersistentFlags().StringP("log-level", "l", "", "enable debug messages")
 	rootCmd.PersistentFlags().StringP("config-file", "c", "", "set config file name")
-	rootCmd.PersistentFlags().StringP("env", "e", "", "(required) set environment name (overrides value set in ENV / IZE_ENV if any of them are set)")
+	rootCmd.PersistentFlags().StringP("env", "e", "", "(required) set environment name (overrides value set in IZE_ENV / ENV if any of them are set)")
 	rootCmd.PersistentFlags().StringP("aws-profile", "p", "", "(required) set AWS profile (overrides value in ize.toml and IZE_AWS_PROFILE / AWS_PROFILE if any of them are set)")
 	rootCmd.PersistentFlags().StringP("aws-region", "r", "", "(required) set AWS region (overrides value in ize.toml and IZE_AWS_REGION / AWS_REGION if any of them are set)")
-	rootCmd.PersistentFlags().StringP("namespace", "n", "", "set namespace")
+	rootCmd.PersistentFlags().StringP("namespace", "n", "", "(required) set namespace (overrides value in ize.toml and IZE_NAMESPACE / NAMESPACE if any of them are set)")
 	rootCmd.PersistentFlags().String("terraform-version", "", "set terraform-version")
 	rootCmd.PersistentFlags().Bool("local-terraform", false, "enable using local terraform")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,11 +156,15 @@ func InitializeConfig(options ...Option) (*Config, error) {
 	logrus.Debug("config file used:", viper.ConfigFileUsed())
 
 	if len(cfg.AwsProfile) == 0 {
-		return nil, fmt.Errorf("AWS profile must be specified using flags or config file\n")
+		return nil, fmt.Errorf("AWS profile must be specified using flags, env or config file\n")
 	}
 
 	if len(cfg.AwsRegion) == 0 {
-		return nil, fmt.Errorf("AWS region must be specified using flags or config file\n")
+		return nil, fmt.Errorf("AWS region must be specified using flags, env or config file\n")
+	}
+
+	if len(cfg.Namespace) == 0 {
+		return nil, fmt.Errorf("namespace must be specified using flags, env or config file\n")
 	}
 
 	sess, err := utils.GetSession(&utils.SessionConfig{


### PR DESCRIPTION
## Changelog: 
- set namespace as required

## Test:
```
psih@DESKTOP-BGN2VJK:~/go/src/github.com/psihachina/ize/examples/simple-monorepo$ ize tunnel
✗ can't configure tunnel: namespace must be specified using flags, env or config file
psih@DESKTOP-BGN2VJK:~/go/src/github.com/psihachina/ize/examples/simple-monorepo$ ize -h
  Opinionated tool for infrastructure and code.

  This tool is designed as a simple wrapper around popular tools,
  so they can be easily integrated in one infra: terraform,
  ECS deployment, serverless, and others.

  It combines infra, build and deploy workflows in one
  and is too simple to be considered sophisticated.
  So let's not do it but rather embrace the simplicity and minimalism.

Usage:
  ize [flags]
  ize [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config      generate global config
  console     connect to a container in the ECS
  deploy      manage deployments
  destroy     destoy anything
  env         generate terraform files
  exec        exec command in ECS container
  gendoc      create docs
  help        Help about any command
  init        initialize project
  logs        stream logs of container in the ECS
  mfa         return export command with AWS MFA credentials
  secrets     manage secrets
  terraform   run terraform
  tunnel      tunnel management
  version     show IZE version

Flags:
  -p, --aws-profile string         (required) set AWS profile (overrides value in ize.toml and IZE_AWS_PROFILE / AWS_PROFILE if any of them are set)
  -r, --aws-region string          (required) set AWS region (overrides value in ize.toml and IZE_AWS_REGION / AWS_REGION if any of them are set)
  -c, --config-file string         set config file name
  -e, --env string                 (required) set environment name (overrides value set in IZE_ENV / ENV if any of them are set)
  -h, --help                       help for ize
      --local-terraform            enable using local terraform
  -l, --log-level string           enable debug messages
  -n, --namespace string           (required) set namespace (overrides value in ize.toml and IZE_NAMESPACE / NAMESPACE if any of them are set)
  -t, --tag string                 set tag
      --terraform-version string   set terraform-version
  -v, --version                    version for ize

Use "ize [command] --help" for more information about a command.
```