### PR TITLE
IZE-275 hide help command

### DIFF
--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -71,6 +71,8 @@ func newApp(ui terminal.UI) (*cobra.Command, error) {
 		},
 	}
 
+	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
+
 	rootCmd.AddCommand(
 		deploy.NewCmdDeploy(ui),
 		destroy.NewCmdDestroy(ui),


### PR DESCRIPTION
## Changelog:
- hide help command

## Test:
```
 psih  ~/go/src/github.com/psihachina/ize   IZE-275-help-command-not-flag-is-inconsistent  ize   
Welcome to IZE
Docs: https://ize.sh/docs
Version: development

  Opinionated tool for infrastructure and code.
  
  This tool is designed as a simple wrapper around popular tools,
  so they can be easily integrated in one infra: terraform,
  ECS deployment, serverless, and others.
  
  It combines infra, build and deploy workflows in one
  and is too simple to be considered sophisticated.
  So let's not do it but rather embrace the simplicity and minimalism.

Usage:
  ize [flags]
  ize [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  config      generate global config
  console     connect to a container in the ECS
  deploy      manage deployments
  destroy     destoy anything
  env         generate terraform files
  exec        exec command in ECS container
  gendoc      create docs
  init        initialize project
  logs        stream logs of container in the ECS
  mfa         return export command with AWS MFA credentials
  secrets     manage secrets
  terraform   run terraform
  tunnel      tunnel management
  version     show IZE version

Flags:
  -p, --aws-profile string         (required) set AWS profile (overrides value in ize.toml and IZE_AWS_PROFILE / AWS_PROFILE if any of them are set)
  -r, --aws-region string          (required) set AWS region (overrides value in ize.toml and IZE_AWS_REGION / AWS_REGION if any of them are set)
  -c, --config-file string         set config file name
  -e, --env string                 (required) set environment name (overrides value set in IZE_ENV / ENV if any of them are set)
  -h, --help                       help for ize
  -l, --log-level string           enable debug messages
  -n, --namespace string           (required) set namespace (overrides value in ize.toml and IZE_NAMESPACE / NAMESPACE if any of them are set)
      --prefer-runtime string      set prefer runtime (native or docker) (default "native")
  -t, --tag string                 set tag
      --terraform-version string   set terraform-version
  -v, --version                    version for ize

Use "ize [command] --help" for more information about a command.
```