### PR TITLE
Fixes IZE-244: Adds environment name to infra deployment header.

### DIFF
--- a/internal/commands/deploy/deploy.go
+++ b/internal/commands/deploy/deploy.go
@@ -265,7 +265,7 @@ func deployAll(ui terminal.UI, o *DeployOptions) error {
 		}
 	}
 
-	ui.Output("Running deploy infra...", terminal.WithHeaderStyle())
+	ui.Output(fmt.Sprintf("[%s] Running deploy infra...", viper.Get("ENV")), terminal.WithHeaderStyle())
 	ui.Output("Execution terraform init...", terminal.WithHeaderStyle())
 
 	err = tf.RunUI(ui)

--- a/internal/commands/deploy/deploy_infra.go
+++ b/internal/commands/deploy/deploy_infra.go
@@ -176,7 +176,7 @@ func (o *DeployInfraOptions) Run() error {
 		}
 	}
 
-	ui.Output("Running deploy infra...", terminal.WithHeaderStyle())
+	ui.Output(fmt.Sprintf("[%s] Running deploy infra...", viper.Get("ENV")), terminal.WithHeaderStyle())
 	ui.Output("Execution terraform init...", terminal.WithHeaderStyle())
 
 	err = tf.RunUI(ui)


### PR DESCRIPTION
(Cancelled) deploy:
```

» [dev] Running deploy infra...

» Execution terraform init...
❌ running terraform v1.1.3...
 │ 2022-04-15T21:22:00.775+0100 [INFO]  Terraform version: 1.1.3
 │ 2022-04-15T21:22:00.775+0100 [INFO]  Go runtime version: go1.17.2
 │ 2022-04-15T21:22:00.775+0100 [INFO]  CLI args: []string{"/Users/dmitry/.ize/vers
 │ ions/terraform/terraform_1.1.3", "init", "-input=true"}

```