### PR TITLE
IZE-293 send username in terraform container

### DIFF
--- a/internal/commands/terraform/terraform.go
+++ b/internal/commands/terraform/terraform.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/hazelops/ize/internal/config"
 	"github.com/hazelops/ize/internal/terraform"
@@ -112,6 +113,7 @@ func (o *TerraformOptions) Run(args []string) error {
 
 	env := []string{
 		fmt.Sprintf("ENV=%v", o.Config.Env),
+		fmt.Sprintf("USER=%v", os.Getenv("USER")),
 		fmt.Sprintf("AWS_PROFILE=%v", o.Config.AwsProfile),
 		fmt.Sprintf("TF_LOG=%v", viper.Get("TF_LOG")),
 		fmt.Sprintf("TF_LOG_PATH=%v", viper.Get("TF_LOG_PATH")),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -202,7 +202,7 @@ func InitConfig() {
 	}
 
 	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
-	if err == nil {
+	if err != nil {
 		viper.SetDefault("TAG", viper.GetString("ENV"))
 		pterm.Warning.Printfln("could not run git rev-parse, the default tag was set: %s", viper.GetString("TAG"))
 	} else {


### PR DESCRIPTION
## Changelog:
- send username in terraform container

## Test:
```
Acquiring state lock. This may take a few moments...
╷
│ Error: Error acquiring the state lock
│
│ Error message: ConditionalCheckFailedException: The conditional request failed
│ Lock Info:
│   ID:        e7238e11-4d2d-c6df-40fa-7465ed544548
│   Path:      nutcorp-tf-state/dev/terraform.tfstate
│   Operation: OperationTypeApply
│   Who:       psih@fe316c6622fb
│   Version:   1.1.3
│   Created:   2022-04-19 07:49:58.560120729 +0000 UTC
│   Info:
│
│
│ Terraform acquires a state lock to protect the state from being written
│ by multiple users at the same time. Please resolve the issue above and try
│ again. For most commands, you can disable locking with the "-lock=false"
│ flag, but this is not recommended.
╵
 ✗  container exit status code 1
```