### PR TITLE
Only one build could be run for DEV releases (IZE-299)

### DIFF
--- a/.github/workflows/create_dev_release.yml
+++ b/.github/workflows/create_dev_release.yml
@@ -1,4 +1,7 @@
 name: "Create dev release"
+concurrency:
+group: ${{ github.workflow }}
+cancel-in-progress: false
 on:
   push:
     branches:


### PR DESCRIPTION
#### What's new:

  - Only one build could be run for DEV releases
  
  When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. 
  Any previously pending job or workflow in the concurrency group will be canceled