### PR TITLE
IZE-306 add a pathError handler to tunnel command

### DIFF
--- a/internal/commands/tunnel/tunnel.go
+++ b/internal/commands/tunnel/tunnel.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net"
 	"os"
@@ -201,6 +202,10 @@ func (o *TunnelOptions) Run(cmd *cobra.Command) error {
 	c.Stdin = os.Stdin
 	c.Dir = viper.GetString("ENV_DIR")
 	if err := c.Run(); err != nil {
+		patherr, ok := err.(*fs.PathError)
+		if ok {
+			return fmt.Errorf("unable to access folder '%s': %w", c.Dir, patherr.Err)
+		}
 		return fmt.Errorf("can't run tunnel up: %w", err)
 	}
 

--- a/internal/commands/tunnel/tunnel_down.go
+++ b/internal/commands/tunnel/tunnel_down.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/fs"
 	"os/exec"
 	"syscall"
 
@@ -84,8 +85,14 @@ func (o *TunnelDownOptions) Run(cmd *cobra.Command) error {
 	c.Stderr = out
 	c.Dir = viper.GetString("ENV_DIR")
 
+	fmt.Println(viper.GetString("ENV_DIR"))
+
 	err := c.Run()
 	if err != nil {
+		patherr, ok := err.(*fs.PathError)
+		if ok {
+			return fmt.Errorf("unable to access folder '%s': %w", c.Dir, patherr.Err)
+		}
 		exiterr := err.(*exec.ExitError)
 		status := exiterr.Sys().(syscall.WaitStatus)
 		if status.ExitStatus() != 255 {

--- a/internal/commands/tunnel/tunnel_up.go
+++ b/internal/commands/tunnel/tunnel_up.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strconv"
@@ -153,6 +154,10 @@ func (o *TunnelUpOptions) Run(cmd *cobra.Command) error {
 	c.Stderr = os.Stderr
 	c.Dir = viper.GetString("ENV_DIR")
 	if err := c.Run(); err != nil {
+		patherr, ok := err.(*fs.PathError)
+		if ok {
+			return fmt.Errorf("unable to access folder '%s': %w", c.Dir, patherr.Err)
+		}
 		return fmt.Errorf("can't run tunnel up: %w", err)
 	}
 


### PR DESCRIPTION
## Changelog:
- add a pathError handler to tunnel command

## Test:
### Trying to run tunnel command with non-existent global env
[![asciicast](https://asciinema.org/a/uGRSroLxfws4O7NGnEtLExH0D.svg)](https://asciinema.org/a/uGRSroLxfws4O7NGnEtLExH0D)