### PR TITLE
IZE-282 ability to show troubleshooting information

### DIFF
--- a/.github/workflows/build_on_push.yml
+++ b/.github/workflows/build_on_push.yml
@@ -34,3 +34,4 @@ jobs:
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         RELEASE_VERSION: ${{ github.sha }}
         FURY_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
+        SHORT_GIT_SHA: $(git rev-parse --short HEAD)

--- a/.github/workflows/build_on_release.yml
+++ b/.github/workflows/build_on_release.yml
@@ -35,6 +35,7 @@ jobs:
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
         RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
         FURY_TOKEN: ${{ secrets.FURY_PUSH_TOKEN }}
+        SHORT_GIT_SHA: $(git rev-parse --short HEAD)
 
     - name: create docs
       run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     dir: .
     main: ./cmd
     ldflags:
-      - -s -w -X 'github.com/hazelops/ize/internal/commands.Version={{.Env.RELEASE_VERSION}}'
+      - -s -w -X 'github.com/hazelops/ize/internal/vesrion.Version={{.Env.RELEASE_VERSION}} -X 'github.com/hazelops/ize/internal/vesrion.GitCommit={{.Env.SHORT_GIT_SHA}}"'
 
 brews:
   - name: ize

--- a/.goreleaser_push.yml
+++ b/.goreleaser_push.yml
@@ -11,7 +11,7 @@ builds:
     dir: .
     main: ./cmd
     ldflags:
-      - -s -w -X 'github.com/hazelops/ize/internal/commands.Version={{.Env.RELEASE_VERSION}}'
+      - -s -w -X 'github.com/hazelops/ize/internal/vesrion.Version={{.Env.RELEASE_VERSION}} -X 'github.com/hazelops/ize/internal/vesrion.GitCommit={{.Env.SHORT_GIT_SHA}}"'
 
 release:
   prerelease: true

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+GIT_COMMIT=$$(git rev-parse --short HEAD)
+GIT_IMPORT="github.com/hazelops/ize/internal/version"
+GIT_DIRTY=$$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
+GOLDFLAGS="-s -w -X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT)$(GIT_DIRTY)"
+CGO_ENABLED?=0
+
 .PHONY: install
 install: bin
 		cp ./ize $(GOPATH)/bin/ize
 
 .PHONY: bin
 bin: 
-	go build -o ./ize ./cmd 
+	CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -o ./ize ./cmd 

--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hazelops/ize/internal/commands/terraform"
 	"github.com/hazelops/ize/internal/commands/tunnel"
 	cfg "github.com/hazelops/ize/internal/config"
+	"github.com/hazelops/ize/internal/version"
 	"github.com/hazelops/ize/pkg/templates"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
@@ -45,21 +46,20 @@ var (
 		TraverseChildren: true,
 		SilenceErrors:    true,
 		Long:             deployIzeDesc,
-		Version:          Version,
+		Version:          version.FullVersionNumber(),
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("%s\n%s\n%s\n\n",
 				pterm.White(pterm.Bold.Sprint("Welcome to IZE")),
 				pterm.Sprintf("%s %s", pterm.Blue("Docs:"), "https://ize.sh/docs"),
-				pterm.Sprintf("%s %s", pterm.Green("Version:"), Version),
+				pterm.Sprintf("%s %s", pterm.Green("Version:"), version.FullVersionNumber()),
 			)
 			cmd.Help()
 		},
 	}
 )
 
-
 func Execute(args []string) {
-	go CheckLatestRealese()
+	go version.CheckLatestRealese()
 
 	if err := rootCmd.Execute(); err != nil {
 		pterm.Error.Println(err)

--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hazelops/ize/internal/commands/logs"
 	"github.com/hazelops/ize/internal/commands/mfa"
 	"github.com/hazelops/ize/internal/commands/secrets"
+	"github.com/hazelops/ize/internal/commands/status"
 	"github.com/hazelops/ize/internal/commands/terraform"
 	"github.com/hazelops/ize/internal/commands/tunnel"
 	cfg "github.com/hazelops/ize/internal/config"
@@ -104,6 +105,7 @@ func addCommands() {
 		exec.NewCmdExec(),
 		configure.NewCmdConfig(),
 		logs.NewCmdLogs(),
+		status.NewDebugCmd(),
 		NewGendocCmd(),
 		NewVersionCmd(),
 	)

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -1,0 +1,98 @@
+package status
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/hazelops/ize/internal/aws/utils"
+	"github.com/hazelops/ize/internal/version"
+	"github.com/pterm/pterm"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func NewDebugCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "show debug information",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			sess, err := utils.GetSession(&utils.SessionConfig{
+				Region:  viper.GetString("aws_region"),
+				Profile: viper.GetString("aws_profile"),
+			})
+			if err != nil {
+				return err
+			}
+
+			resp, err := sts.New(sess).GetCallerIdentity(
+				&sts.GetCallerIdentityInput{},
+			)
+			if err != nil {
+				return err
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("can`t complete options: %w", err)
+			}
+
+			dt := pterm.DefaultTable
+
+			pterm.DefaultSection.Println("IZE Info")
+
+			dt.WithData(pterm.TableData{
+				{"ENV", viper.GetString("env")},
+				{"TAG", viper.GetString("tag")},
+				{"INFRA DIR", viper.GetString("infra_dir")},
+				{"PWD", cwd},
+				{"IZE VERSION", version.Version},
+				{"IZE GIT REVISION", version.GitCommit},
+				{"ENV DIR", viper.GetString("env_dir")},
+			}).WithLeftAlignment().Render()
+
+			pterm.DefaultSection.Println("System Info")
+
+			dt.WithData(pterm.TableData{
+				{"OS", runtime.GOOS},
+				{"ARCH", runtime.GOARCH},
+			}).WithLeftAlignment().Render()
+
+			guo, err := iam.New(sess).GetUser(&iam.GetUserInput{})
+			if err != nil {
+				return err
+			}
+
+			luto, err := iam.New(sess).ListUserTags(&iam.ListUserTagsInput{
+				UserName: guo.User.UserName,
+			})
+			if err != nil {
+				return err
+			}
+
+			devEnvName := ""
+
+			for _, k := range luto.Tags {
+				if *k.Key == "devEnvironmentName" {
+					devEnvName = *k.Value
+				}
+			}
+
+			pterm.DefaultSection.Println("AWS Environment Info")
+
+			dt.WithData(pterm.TableData{
+				{"AWS_DEV_ENV_NAME", devEnvName},
+				{"AWS PROFILE", fmt.Sprintf("%s-%s", viper.GetString("env"), viper.GetString("namespace"))},
+				{"AWS USER", *guo.User.UserName},
+				{"AWS ACCOUNT", *resp.Account},
+			}).WithLeftAlignment().Render()
+
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -1,18 +1,11 @@
 package commands
 
 import (
-	"encoding/json"
 	"io"
-	"log"
-	"net/http"
 	"text/template"
 
-	"github.com/Masterminds/semver"
-	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 )
-
-var Version = "development"
 
 func NewVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -31,34 +24,4 @@ func tmpl(w io.Writer, text string, data interface{}) error {
 	t := template.New("top")
 	template.Must(t.Parse(text))
 	return t.Execute(w, data)
-}
-
-func GetVersionNumber() string {
-	return Version
-}
-
-func CheckLatestRealese() {
-	_, err := semver.NewVersion(Version)
-	if err != nil {
-		return
-	}
-
-	resp, err := http.Get("https://api.github.com/repos/hazelops/ize/releases/latest")
-	if err != nil {
-		log.Fatalln(err)
-	}
-
-	var gr gitResponse
-
-	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
-		log.Fatal(err)
-	}
-
-	if Version != gr.Version {
-		pterm.Warning.Printfln("Newest version is %s current version is %s. Consider upgrading.", gr.Version, Version)
-	}
-}
-
-type gitResponse struct {
-	Version string `json:"tag_name"`
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,58 @@
+package version
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/Masterminds/semver"
+	"github.com/pterm/pterm"
+)
+
+var (
+	GitCommit string
+	Version   = "development"
+)
+
+func FullVersionNumber() string {
+	var versionString bytes.Buffer
+
+	if Version == "development" {
+		return "development"
+	}
+
+	fmt.Fprintf(&versionString, "%s", Version)
+	if GitCommit != "" {
+		fmt.Fprintf(&versionString, " (%s)", GitCommit)
+	}
+
+	return versionString.String()
+}
+
+func CheckLatestRealese() {
+	_, err := semver.NewVersion(Version)
+	if err != nil {
+		return
+	}
+
+	resp, err := http.Get("https://api.github.com/repos/hazelops/ize/releases/latest")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	var gr gitResponse
+
+	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
+		log.Fatal(err)
+	}
+
+	if Version != gr.Version {
+		pterm.Warning.Printfln("Newest version is %s current version is %s. Consider upgrading.", gr.Version, Version)
+	}
+}
+
+type gitResponse struct {
+	Version string `json:"tag_name"`
+}


### PR DESCRIPTION
## Changelog:
- add version package
- add git SHA to goreleaser
- add status command

## Test:
```
 AWS: default psih  ~  ize status
 ⚠  could not run git rev-parse, the default tag was set: dev

# IZE Info

ENV              | dev
TAG              | dev
INFRA DIR        | /home/psih/.ize
PWD              | /home/psih
IZE VERSION      | development
IZE GIT REVISION | ec181a0+CHANGES
ENV DIR          | /home/psih/.ize/nutcorp/dev

# System Info

OS   | linux
ARCH | amd64

# AWS Environment Info

AWS_DEV_ENV_NAME |
AWS PROFILE      | dev-nutcorp
AWS USER         | nikita
AWS ACCOUNT      | xxxxxxxxxxx
```

### in nutcorp-backend
```
 AWS: default psih  ~/go/src/github.com/psihachina/nutcorp-backend   develop ±  ize status

# IZE Info

ENV              | dev
TAG              | 1e40ac8
INFRA DIR        | /home/psih/go/src/github.com/psihachina/nutcorp-backend/.infra
PWD              | /home/psih/go/src/github.com/psihachina/nutcorp-backend
IZE VERSION      | development
IZE GIT REVISION | ec181a0+CHANGES
ENV DIR          | /home/psih/go/src/github.com/psihachina/nutcorp-backend/.infra/env/dev

# System Info

OS   | linux
ARCH | amd64

# AWS Environment Info

AWS_DEV_ENV_NAME |
AWS PROFILE      | dev-nutcorp
AWS USER         | nikita
AWS ACCOUNT      | xxxxxxxxxx
```