### PR TITLE
IZE-313 test ize tunnel up down status

### DIFF
--- a/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
+++ b/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
@@ -1,5 +1,4 @@
 aws_region = "us-east-1"
-aws_profile = "nutcorp-dev"
 env = "testnut"
 namespace = "nutcorp"
 terraform_version = "1.1.7"

--- a/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
+++ b/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
@@ -1,4 +1,5 @@
 aws_region = "us-east-1"
+aws_profile = "nutcorp-dev"
 env = "testnut"
 namespace = "nutcorp"
 terraform_version = "1.1.7"

--- a/examples/ecs-apps-monorepo/.ize/env/testnut/ize.toml
+++ b/examples/ecs-apps-monorepo/.ize/env/testnut/ize.toml
@@ -1,4 +1,3 @@
-aws_profile = "nutcorp-dev"
 aws_region = "us-east-1"
 env = "testnut"
 namespace = "testnut"

--- a/test-e2e/bastion_tunnel_test.go
+++ b/test-e2e/bastion_tunnel_test.go
@@ -1,0 +1,162 @@
+//go:build e2e && bastion_tunnel
+
+package test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIzeGenEnv_bastion_tunnel(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("gen", "env")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize gen env: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Generate terraform files completed") {
+		t.Errorf("No success message detected after gen env:\n%s", stdout)
+	}
+}
+
+func TestIzeDeployAll_bastion_tunnel(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	foundIZEConfig := false
+	err := filepath.Walk(examplesRootDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.Name() == "ize.toml" {
+			foundIZEConfig = true
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed listing files in project template path %s: %s", examplesRootDir, err)
+	}
+
+	if !foundIZEConfig {
+		t.Fatalf("No ize.toml file in project template path %s", examplesRootDir)
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("deploy", "--auto-approve", "--prefer-runtime=docker")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Deploy all completed!") {
+		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+	}
+}
+
+func TestIzeTunnelUp(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("tunnel")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize tunnel: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Tunnel is up! Forwarded ports:") {
+		t.Errorf("No success message detected after tunnel:\n%s", stdout)
+	}
+}
+
+func TestIzeTunnelStatus(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("tunnel", "status")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize tunnel status: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Tunnel is up. Forwarding config:") {
+		t.Errorf("No success message detected after tunnel status:\n%s", stdout)
+	}
+}
+
+func TestIzeTunnelDown(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("tunnel", "down")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize tunnel down: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Tunnel is down!") {
+		t.Errorf("No success message detected after tunnel down:\n%s", stdout)
+	}
+}
+
+func TestIzeDestroyAll_bastion_tunnel(t *testing.T) {
+	if examplesRootDir == "" {
+		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
+	}
+
+	ize := NewBinary(t, izeBinary, examplesRootDir)
+
+	stdout, stderr, err := ize.RunRaw("destroy", "--auto-approve", "--prefer-runtime=docker")
+
+	if err != nil {
+		t.Errorf("error: %s", err)
+	}
+
+	if stderr != "" {
+		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+	}
+
+	if !strings.Contains(stdout, "Destroy all completed!") {
+		t.Errorf("No success message detected after all destroy:\n%s", stdout)
+	}
+}

--- a/test-e2e/ecs_apps_test.go
+++ b/test-e2e/ecs_apps_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && ecs_apps
 
 package test
 
@@ -25,7 +24,7 @@ var (
 	exampleSquibbyApiKey = ""
 )
 
-func TestIzeGenEnv(t *testing.T) {
+func TestIzeGenEnv_ecs_apps(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
@@ -146,7 +145,7 @@ func TestIzeSecretsPushSquibby(t *testing.T) {
 	}
 }
 
-func TestIzeDeployAll(t *testing.T) {
+func TestIzeDeployAll_ecs_apps(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
@@ -262,7 +261,7 @@ func randInt(min int, max int) int {
 	return min + rand.Intn(max-min)
 }
 
-func TestIzeDestroyAll(t *testing.T) {
+func TestIzeDestroyAll_ecs_apps(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}

--- a/test-e2e/terraform_test.go
+++ b/test-e2e/terraform_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && terraform
 
 package test
 

--- a/test-e2e/util.go
+++ b/test-e2e/util.go
@@ -1,6 +1,3 @@
-//go:build e2e
-// +build e2e
-
 package test
 
 import (
@@ -58,7 +55,6 @@ func (b *binary) NewCmd(args ...string) *exec.Cmd {
 	cmd.Dir = b.workingDir
 	cmd.Env = os.Environ()
 
-	cmd.Env = append(cmd.Env, "CHECKPOINT_DISABLE=1")
 	return cmd
 }
 


### PR DESCRIPTION
## Changelog:
- add e2e test of bastion tunnel monorepo
- add aws_profile to basion tunnel monorepo
- some fixes

## Test:
```
psih ~ go test -v --timeout 0 --tags "e2e bastion_tunnel" ./test-e2e 
=== RUN   TestIzeGenEnv_bastion_tunnel
--- PASS: TestIzeGenEnv_bastion_tunnel (4.17s)
=== RUN   TestIzeDeployAll_bastion_tunnel
--- PASS: TestIzeDeployAll_bastion_tunnel (189.39s)
=== RUN   TestIzeTunnelUp
--- PASS: TestIzeTunnelUp (14.99s)
=== RUN   TestIzeTunnelStatus
--- PASS: TestIzeTunnelStatus (3.21s)
=== RUN   TestIzeTunnelDown
--- PASS: TestIzeTunnelDown (3.41s)
=== RUN   TestIzeDestroyAll_bastion_tunnel
--- PASS: TestIzeDestroyAll_bastion_tunnel (175.68s)
PASS
ok      github.com/hazelops/ize/test-e2e        390.843s```