### PR TITLE
Status fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CGO_ENABLED?=0
 
 .PHONY: install
 install: bin
-		cp ./ize $(GOPATH)/bin/ize
+		mv ./ize $(GOPATH)/bin/ize
 
 .PHONY: bin
 bin: 

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -43,7 +43,7 @@ func NewDebugCmd() *cobra.Command {
 				{"PREFER_RUNTIME", viper.GetString("prefer_runtime")},
 			}).WithLeftAlignment().Render()
 
-			pterm.DefaultSection.Println("Terrafor Info")
+			pterm.DefaultSection.Println("Terraform Info")
 			dt.WithData(pterm.TableData{
 				{"TERRAFORM_VERSION", viper.GetString("terraform_version")},
 			}).WithLeftAlignment().Render()
@@ -57,7 +57,7 @@ func NewDebugCmd() *cobra.Command {
 
 			pterm.DefaultSection.Println("AWS Environment Info")
 
-			if len(viper.GetString("aws_profile")) > 1 {
+			if len(viper.GetString("aws_profile")) > 0 {
 				sess, err := utils.GetSession(&utils.SessionConfig{
 					Region:  viper.GetString("aws_region"),
 					Profile: viper.GetString("aws_profile"),
@@ -94,7 +94,7 @@ func NewDebugCmd() *cobra.Command {
 				if aerr, ok := err.(awserr.Error); ok {
 					switch aerr.Code() {
 					case "NoSuchEntity":
-						return fmt.Errorf("error obtaining AWS user with %s aws profile: %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
+						return fmt.Errorf("error obtaining AWS user with aws_profile=%s: username %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
 					default:
 						return err
 					}

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -2,13 +2,13 @@ package status
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hazelops/ize/internal/aws/utils"
+	"os"
+	"runtime"
+
 	"github.com/hazelops/ize/internal/version"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -22,21 +22,6 @@ func NewDebugCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 
-			sess, err := utils.GetSession(&utils.SessionConfig{
-				Region:  viper.GetString("aws_region"),
-				Profile: viper.GetString("aws_profile"),
-			})
-			if err != nil {
-				return err
-			}
-
-			resp, err := sts.New(sess).GetCallerIdentity(
-				&sts.GetCallerIdentityInput{},
-			)
-			if err != nil {
-				return err
-			}
-
 			cwd, err := os.Getwd()
 			if err != nil {
 				return fmt.Errorf("can't load options for a command: %w", err)
@@ -48,12 +33,19 @@ func NewDebugCmd() *cobra.Command {
 
 			dt.WithData(pterm.TableData{
 				{"ENV", viper.GetString("env")},
+				{"NAMESPACE", viper.GetString("namepsace")},
 				{"TAG", viper.GetString("tag")},
 				{"INFRA DIR", viper.GetString("infra_dir")},
 				{"PWD", cwd},
 				{"IZE VERSION", version.Version},
-				{"IZE GIT REVISION", version.GitCommit},
+				{"GIT REVISION", version.GitCommit},
 				{"ENV DIR", viper.GetString("env_dir")},
+				{"PREFER_RUNTIME", viper.GetString("prefer_runtime")},
+			}).WithLeftAlignment().Render()
+
+			pterm.DefaultSection.Println("Terrafor Info")
+			dt.WithData(pterm.TableData{
+				{"TERRAFORM_VERSION", viper.GetString("terraform_version")},
 			}).WithLeftAlignment().Render()
 
 			pterm.DefaultSection.Println("System Info")
@@ -63,44 +55,78 @@ func NewDebugCmd() *cobra.Command {
 				{"ARCH", runtime.GOARCH},
 			}).WithLeftAlignment().Render()
 
-			guo, err := iam.New(sess).GetUser(&iam.GetUserInput{})
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case "NoSuchEntity":
-					return fmt.Errorf("error obtaining AWS user with %s aws profile: %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
-				default:
-					return err
-				}
-			}
-
-			luto, err := iam.New(sess).ListUserTags(&iam.ListUserTagsInput{
-				UserName: guo.User.UserName,
-			})
-			if aerr, ok := err.(awserr.Error); ok {
-				switch aerr.Code() {
-				case "NoSuchEntity":
-					return fmt.Errorf("error obtaining AWS user with %s aws profile: %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
-				default:
-					return err
-				}
-			}
-
-			devEnvName := ""
-
-			for _, k := range luto.Tags {
-				if *k.Key == "devEnvironmentName" {
-					devEnvName = *k.Value
-				}
-			}
-
 			pterm.DefaultSection.Println("AWS Environment Info")
 
-			dt.WithData(pterm.TableData{
-				{"AWS_DEV_ENV_NAME", devEnvName},
-				{"AWS PROFILE", fmt.Sprintf("%s-%s", viper.GetString("env"), viper.GetString("namespace"))},
-				{"AWS USER", *guo.User.UserName},
-				{"AWS ACCOUNT", *resp.Account},
-			}).WithLeftAlignment().Render()
+			if len(viper.GetString("aws_profile")) > 1 {
+				sess, err := utils.GetSession(&utils.SessionConfig{
+					Region:  viper.GetString("aws_region"),
+					Profile: viper.GetString("aws_profile"),
+				})
+				if aerr, ok := err.(awserr.Error); ok {
+					switch aerr.Code() {
+					case "NoCredentialProviders":
+						return fmt.Errorf("Error estabilishing a session with AWS. Please make sure your credentials are valid. Using aws_profile: %s", viper.GetString("aws_profile"))
+					default:
+						return err
+					}
+				}
+
+				resp, err := sts.New(sess).GetCallerIdentity(
+					&sts.GetCallerIdentityInput{},
+				)
+				if err != nil {
+					return err
+				}
+
+				guo, err := iam.New(sess).GetUser(&iam.GetUserInput{})
+				if aerr, ok := err.(awserr.Error); ok {
+					switch aerr.Code() {
+					case "NoSuchEntity":
+						return fmt.Errorf("error obtaining AWS user with aws_profile=%s: username %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
+					default:
+						return err
+					}
+				}
+
+				luto, err := iam.New(sess).ListUserTags(&iam.ListUserTagsInput{
+					UserName: guo.User.UserName,
+				})
+				if aerr, ok := err.(awserr.Error); ok {
+					switch aerr.Code() {
+					case "NoSuchEntity":
+						return fmt.Errorf("error obtaining AWS user with %s aws profile: %s is not found in account %s", viper.GetString("aws_profile"), *guo.User.UserName, *resp.Account)
+					default:
+						return err
+					}
+				}
+
+				devEnvName := ""
+
+				for _, k := range luto.Tags {
+					if *k.Key == "devEnvironmentName" {
+						devEnvName = *k.Value
+					}
+				}
+
+				dt.WithData(pterm.TableData{
+					{"AWS PROFILE", viper.GetString("aws_profile")},
+					{"AWS USER", *guo.User.UserName},
+					{"AWS ACCOUNT", *resp.Account},
+				}).WithLeftAlignment().Render()
+
+				if len(devEnvName) > 0 {
+					dt.WithData(pterm.TableData{
+						{"AWS_DEV_ENV_NAME", devEnvName},
+					}).WithLeftAlignment().Render()
+				}
+
+			} else {
+
+				pterm.Println("No AWS profile credentials detected. Parameters used:")
+				dt.WithData(pterm.TableData{
+					{"AWS PROFILE", viper.GetString("aws_profile")},
+				}).WithLeftAlignment().Render()
+			}
 
 			return nil
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -149,7 +149,7 @@ func GetConfig() (*Config, error) {
 
 	cfg.IsPlainText = plainText
 
-	if viper.GetString("prefer-runtime") == "docker" {
+	if viper.GetString("PREFER_RUNTIME") == "docker" {
 		cfg.IsDockerRuntime = true
 	}
 
@@ -167,6 +167,7 @@ func InitConfig() {
 	viper.SetDefault("NAMESPACE", os.Getenv("NAMESPACE"))
 	// TODO: those static defaults should probably go to a separate package and/or function. Also would include image names and such.
 	viper.SetDefault("TERRAFORM_VERSION", "1.1.3")
+	viper.SetDefault("PREFER_RUNTIME", "docker")
 
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,7 +167,7 @@ func InitConfig() {
 	viper.SetDefault("NAMESPACE", os.Getenv("NAMESPACE"))
 	// TODO: those static defaults should probably go to a separate package and/or function. Also would include image names and such.
 	viper.SetDefault("TERRAFORM_VERSION", "1.1.3")
-	viper.SetDefault("PREFER_RUNTIME", "docker")
+	viper.SetDefault("PREFER_RUNTIME", "native")
 
 	home, err := os.UserHomeDir()
 	if err != nil {


### PR DESCRIPTION
- Update ize install so it doesn't store binary in the root
- Update order of calling AWS Auth
- Show actual aws profile that is passed
- Improve AWS status errors
- Use PREFER_RUNTIME in viper as a base value
```
❯ ize status
# IZE Info

ENV            | testnut
NAMESPACE      |
TAG            | 78357b4
INFRA DIR      | /Users/dmitry/dev/hazelops/ize/examples/ecs-apps-monorepo/.ize
PWD            | /Users/dmitry/dev/hazelops/ize/examples/ecs-apps-monorepo
IZE VERSION    | development
GIT REVISION   | 78357b4+CHANGES
ENV DIR        | /Users/dmitry/dev/hazelops/ize/examples/ecs-apps-monorepo/.ize/env/testnut
PREFER_RUNTIME | native

# Terraform Info

TERRAFORM_VERSION | 1.1.7

# System Info

OS   | darwin
ARCH | amd64

# AWS Environment Info

AWS PROFILE | nutcorp-dev
AWS USER    | dmitry
AWS ACCOUNT | <redacted>
AWS_DEV_ENV_NAME | dmitry
```

