### PR TITLE
IZE-333 add an additional message if ENV is not set

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,8 +203,12 @@ func InitConfig() {
 
 	out, err := exec.Command("git", "rev-parse", "--short", "HEAD").Output()
 	if err != nil {
-		viper.SetDefault("TAG", viper.GetString("ENV"))
-		pterm.Warning.Printfln("Could not run git rev-parse, the default tag was set: %s", viper.GetString("TAG"))
+		if viper.GetString("ENV") == "" {
+			pterm.Warning.Printfln("Can't read ENV, please set the value via --env flag or env variable")
+		} else {
+			viper.SetDefault("TAG", viper.GetString("ENV"))
+			pterm.Warning.Printfln("Could not run git rev-parse, the default tag was set: %s", viper.GetString("TAG"))
+		}
 	} else {
 		viper.SetDefault("TAG", strings.Trim(string(out), "\n"))
 	}


### PR DESCRIPTION
## Changelog:
- add an additional message if ENV is not set

## Test:
[![asciicast](https://asciinema.org/a/ci7XeQc6XSbgtgwk9Jp88UoPp.svg)](https://asciinema.org/a/ci7XeQc6XSbgtgwk9Jp88UoPp)