### PR TITLE
Ize 340 documentation ize secrets edit

### DIFF
--- a/internal/commands/secrets/secrets_edit.go
+++ b/internal/commands/secrets/secrets_edit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/hazelops/ize/internal/config"
+	"github.com/hazelops/ize/pkg/templates"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -19,6 +20,12 @@ type SecretsEditOptions struct {
 	FilePath string
 }
 
+var secretsEditExample = templates.Examples(`
+	# Edit secrets
+	ize secrets --file example-service.json
+    # This will open your secrets file with local text editor
+`)
+
 func NewSecretsEditFlags() *SecretsEditOptions {
 	return &SecretsEditOptions{}
 }
@@ -27,10 +34,11 @@ func NewCmdSecretsEdit() *cobra.Command {
 	o := NewSecretsEditFlags()
 
 	cmd := &cobra.Command{
-		Use:   "edit",
-		Short: "Edit secrets file",
-		Long:  "This command open secrets file in default text editor",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "edit",
+		Example: secretsEditExample,
+		Short:   "Edit secrets file",
+		Long:    "This command open secrets file in default text editor",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 

--- a/internal/commands/secrets/secrets_push.go
+++ b/internal/commands/secrets/secrets_push.go
@@ -29,8 +29,7 @@ type SecretsPushOptions struct {
 var secretsPushExample = templates.Examples(`
 	# Push secrets
 	ize secrets push --backend ssm --file example-service.json --force
-    # This will push your secrets from a "example-service.json" file to the AWS SSM storage 
-    # with force option(values will be overwritten if exist)
+    # This will push your secrets from a "example-service.json" file to the AWS SSM storage with force option(values will be overwritten if exist)
 `)
 
 func NewSecretsPushFlags() *SecretsPushOptions {

--- a/internal/commands/secrets/secrets_push.go
+++ b/internal/commands/secrets/secrets_push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hazelops/ize/internal/config"
+	"github.com/hazelops/ize/pkg/templates"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -25,6 +26,13 @@ type SecretsPushOptions struct {
 	Force       bool
 }
 
+var secretsPushExample = templates.Examples(`
+	# Push secrets
+	ize secrets push --backend ssm --file example-service.json --force
+    # This will push your secrets from a "example-service.json" file to the AWS SSM storage 
+    # with force option(values will be overwritten if exist)
+`)
+
 func NewSecretsPushFlags() *SecretsPushOptions {
 	return &SecretsPushOptions{}
 }
@@ -33,10 +41,11 @@ func NewCmdSecretsPush() *cobra.Command {
 	o := NewSecretsPushFlags()
 
 	cmd := &cobra.Command{
-		Use:   "push",
-		Short: "Push secrets to a key-value storage (like SSM)",
-		Long:  "This command pushes secrets from a local file to a key-value storage (like SSM)",
-		Args:  cobra.MinimumNArgs(1),
+		Use:     "push",
+		Example: secretsPushExample,
+		Short:   "Push secrets to a key-value storage (like SSM)",
+		Long:    "This command pushes secrets from a local file to a key-value storage (like SSM)",
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 

--- a/internal/commands/secrets/secrets_rm.go
+++ b/internal/commands/secrets/secrets_rm.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/hazelops/ize/internal/config"
+	"github.com/hazelops/ize/pkg/templates"
 	"github.com/hazelops/ize/pkg/terminal"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -20,6 +21,12 @@ type SecretsRemoveOptions struct {
 	ui          terminal.UI
 }
 
+var secretsRemoveExample = templates.Examples(`
+	# Remove secrets
+	ize secrets rm --backend ssm
+    # This will remove your secrets from the AWS SSM storage
+`)
+
 func NewSecretsRemoveFlags() *SecretsRemoveOptions {
 	return &SecretsRemoveOptions{}
 }
@@ -29,6 +36,7 @@ func NewCmdSecretsRemove() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "rm",
+		Example:          secretsRemoveExample,
 		Short:            "Remove secrets from storage",
 		Long:             "This command removes secrets from storage",
 		TraverseChildren: true,


### PR DESCRIPTION
#### What's new:

 - Added examples to the ize secrets


#### Testing done:

 - 'ize secrets rm' :
<img width="1498" alt="screenshot 2022-06-03 at 21 20 05" src="https://user-images.githubusercontent.com/24703846/171923486-d73bafd0-6529-4d13-aa35-dc2cbaa49a92.png">

- 'ize secrets push' : 
<img width="1529" alt="screenshot 2022-06-03 at 21 20 15" src="https://user-images.githubusercontent.com/24703846/171923503-0eeb271b-2e45-470e-b1e3-fec2bf764806.png">

- 'ize secrets edit' :
<img width="1604" alt="screenshot 2022-06-03 at 21 20 26" src="https://user-images.githubusercontent.com/24703846/171923524-ede0ee14-d458-4566-bf4c-5e47e797482b.png">
