### PR TITLE
IZE-342 add success message to ize init command

### DIFF
--- a/internal/commands/initialize/initialize.go
+++ b/internal/commands/initialize/initialize.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hazelops/ize/examples"
 	"github.com/hazelops/ize/internal/generate"
 	"github.com/hazelops/ize/pkg/templates"
+	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -82,10 +83,12 @@ func (o *InitOptions) Validate(cmd *cobra.Command) error {
 }
 
 func (o *InitOptions) Run() error {
-	_, err := generate.GenerateFiles(o.Template, o.Output)
+	dest, err := generate.GenerateFiles(o.Template, o.Output)
 	if err != nil {
 		return err
 	}
+
+	pterm.Success.Printfln(`Initialized project from template "%s" to %s`, o.Template, dest)
 
 	return nil
 }

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -32,7 +32,7 @@ func determineRepoDir(template string, destionation string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "", nil
+		return destionation, nil
 	} else {
 		return "", fmt.Errorf("supported only repository url or internal examples")
 	}


### PR DESCRIPTION
## Changelog:
- add success message to ize init command

## Test:
[![asciicast](https://asciinema.org/a/EMeHmAtGOktY2iDUBwMR7Pv3s.svg)](https://asciinema.org/a/EMeHmAtGOktY2iDUBwMR7Pv3s)