### PR TITLE
IZE-367 IZE-382 IZE-381 tests updated

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -47,6 +47,7 @@ jobs:
     name: ECS Apps Monorepo
     needs: build
     strategy:
+      max-parallel: 1
       matrix:
         os:
           - ubuntu-latest
@@ -107,9 +108,10 @@ jobs:
         continue-on-error: true
 
   bastion-tunnel-monorepo:
-    name: Tunnel
+    name: Bastion tunnel monorepo
     needs: build
     strategy:
+      max-parallel: 1
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest  ]
     runs-on: ${{ matrix.os }}
@@ -170,6 +172,7 @@ jobs:
     name: Terraform
     needs: build
     strategy:
+      max-parallel: 1
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.os }}
     env:
       ENV: test-ecs-apps
@@ -100,7 +101,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test --timeout 0 --tags="e2e ecs_apps" ./...
+          go test -v --timeout 0 --tags="e2e ecs_apps" ./test-e2e
         env:
           IZE_EXAMPLES_PATH: ${{ github.workspace }}/examples/${{ github.job }}
         continue-on-error: true
@@ -110,7 +111,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest  ]
     runs-on: ${{ matrix.os }}
     env:
       ENV: bastion-tunnel
@@ -135,7 +136,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Prepare Test Environment
-        run: mv "${{ github.workspace }}/examples/ecs-apps-monorepo/.ize/env/testnut" "${{ github.workspace }}/examples/ecs-apps-monorepo/.ize/env/${{ env.ENV }}"
+        run: mv "${{ github.workspace }}/examples/${{ github.job }}/.ize/env/testnut" "${{ github.workspace }}/examples/${{ github.job }}/.ize/env/${{ env.ENV }}"
 
       - uses: actions/download-artifact@v3
         with:
@@ -160,9 +161,9 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test --timeout 0 --tags="e2e bastion_tunnel" ./...
+          go test -v --timeout 0 --tags="e2e bastion_tunnel" ./test-e2e
         env:
-          IZE_EXAMPLES_PATH: ${{ github.workspace }}/examples/bastion-tunnel-monorepo
+          IZE_EXAMPLES_PATH: ${{ github.workspace }}/examples/${{ github.job }}
         continue-on-error: true
 
   test-terraform:
@@ -220,7 +221,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          go test --timeout 0 --tags="e2e terraform" ./...
+          go test -v --timeout 0 --tags="e2e terraform" ./test-e2e
         env:
           IZE_EXAMPLES_PATH: ${{ github.workspace }}/examples/ecs-apps-monorepo
         continue-on-error: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
+          # - macos-latest
     runs-on: ${{ matrix.os }}
     env:
       ENV: test-ecs-apps

--- a/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
+++ b/examples/bastion-tunnel-monorepo/.ize/env/testnut/ize.toml
@@ -1,4 +1,3 @@
 aws_region = "us-east-1"
-env = "testnut"
 namespace = "nutcorp"
 terraform_version = "1.1.7"

--- a/examples/ecs-apps-monorepo/.ize/env/testnut/ize.toml
+++ b/examples/ecs-apps-monorepo/.ize/env/testnut/ize.toml
@@ -1,5 +1,4 @@
 aws_region = "us-east-1"
-env = "testnut"
 namespace = "testnut"
 terraform_version = "1.1.7"
 

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/oklog/ulid v1.3.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/image-spec v1.0.2 // indirect
-	github.com/psihachina/terraform-switcher v0.13.1251
+	github.com/psihachina/terraform-switcher v0.13.1275
 	github.com/pterm/pterm v0.12.41
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,7 @@ github.com/cheggaaa/pb/v3 v3.0.5 h1:lmZOti7CraK9RSjzExsY53+WWfub9Qv13B5m4ptEoPE=
 github.com/cheggaaa/pb/v3 v3.0.5/go.mod h1:X1L61/+36nz9bjIsrDU52qHKOQukUQe2Ge+YvGuquCw=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
@@ -866,6 +867,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZf4=
 github.com/hashicorp/hcl/v2 v2.12.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
+github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 h1:PFfGModn55JA0oBsvFghhj0v93me+Ctr3uHC/UmFAls=
 github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80/go.mod h1:Cxv+IJLuBiEhQ7pBYGEuORa0nr4U994pE8mYLuFd7v0=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -875,6 +877,7 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
+github.com/hashicorp/terraform-config-inspect v0.0.0-20211115214459-90acf1ca460f h1:R8UIC07Ha9jZYkdcJ51l4ownCB8xYwfJtrgZSMvqjWI=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20211115214459-90acf1ca460f/go.mod h1:Z0Nnk4+3Cy89smEbrq+sl1bxc9198gIP4I7wcQF6Kqs=
 github.com/hashicorp/uuid v0.0.0-20160311170451-ebb0a03e909c/go.mod h1:fHzc09UnyJyqyW+bFuq864eh+wC7dj65aXmXLRe5to0=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
@@ -930,6 +933,7 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -979,6 +983,7 @@ github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
+github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626 h1:33Ys8SnkRfz5ojdG853pyT/2Iqbk95PVm+QrC5XvI70=
 github.com/lunixbochs/vtclean v0.0.0-20170504063817-d14193dfc626/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -989,6 +994,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/manifoldco/promptui v0.2.2-0.20180308161052-c0c0d3afc6a0 h1:m+7Wac/EstF4dyXS4Il4eNK1GM/yMI0jgylBB6Ztg0c=
 github.com/manifoldco/promptui v0.2.2-0.20180308161052-c0c0d3afc6a0/go.mod h1:zoCNXiJnyM03LlBgTsWv8mq28s7aTC71UgKasqRJHww=
 github.com/maratori/testpackage v1.0.1/go.mod h1:ddKdw+XG0Phzhx8BFDTKgpWP4i7MpApTE5fXSKAqwDU=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
@@ -1183,6 +1189,7 @@ github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTm
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30 h1:BHT1/DKsYDGkUgQ2jmMaozVcdk+sVfz0+1ZJq4zkWgw=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -1259,6 +1266,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/psihachina/terraform-switcher v0.13.1251 h1:ld5l0ne2i+K9LPkI8Zn0twfAR1ZaG6rKEvexxpb4ygo=
 github.com/psihachina/terraform-switcher v0.13.1251/go.mod h1:NoeJvaxDuRukVgcMZl1SsHTn+AZ1ZxOtgGjTsRkqgdQ=
+github.com/psihachina/terraform-switcher v0.13.1275 h1:bpg6XOT9+MC2xYq8tIddT8XteHDHs2l/SAkG0Qzl8Io=
+github.com/psihachina/terraform-switcher v0.13.1275/go.mod h1:NoeJvaxDuRukVgcMZl1SsHTn+AZ1ZxOtgGjTsRkqgdQ=
 github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=
 github.com/pterm/pterm v0.12.29/go.mod h1:WI3qxgvoQFFGKGjGnJR849gU0TsEOvKn5Q8LlY1U7lg=
 github.com/pterm/pterm v0.12.30/go.mod h1:MOqLIyMOgmTDz9yorcYbcw+HsgoZo3BQfg2wtl3HEFE=

--- a/internal/commands/status/status.go
+++ b/internal/commands/status/status.go
@@ -2,12 +2,13 @@ package status
 
 import (
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hazelops/ize/internal/aws/utils"
-	"os"
-	"runtime"
 
 	"github.com/hazelops/ize/internal/version"
 	"github.com/pterm/pterm"
@@ -33,7 +34,7 @@ func NewDebugCmd() *cobra.Command {
 
 			dt.WithData(pterm.TableData{
 				{"ENV", viper.GetString("env")},
-				{"NAMESPACE", viper.GetString("namepsace")},
+				{"NAMESPACE", viper.GetString("namespace")},
 				{"TAG", viper.GetString("tag")},
 				{"INFRA DIR", viper.GetString("infra_dir")},
 				{"PWD", cwd},

--- a/internal/commands/tunnel/tunnel.go
+++ b/internal/commands/tunnel/tunnel.go
@@ -186,13 +186,16 @@ func (o *TunnelOptions) Run(cmd *cobra.Command) error {
 		return fmt.Errorf("can't run tunnel: %w", err)
 	}
 
-	c := exec.Command(
-		"ssh", "-M", "-t", "-S", "bastion.sock", "-fN",
+	args := []string{"-M", "-t", "-S", "bastion.sock", "-fN",
 		"-o", "StrictHostKeyChecking=no",
 		fmt.Sprintf("ubuntu@%s", o.BastionHostID),
-		"-F", sshConfigPath,
-		"-i", getPrivateKey(o.PrivateKeyFile),
-	)
+		"-F", sshConfigPath}
+
+	if _, err := os.Stat(o.PrivateKeyFile); !os.IsNotExist(err) {
+		args = append(args, "-i", o.PrivateKeyFile)
+	}
+
+	c := exec.Command("ssh", args...)
 
 	c.Dir = viper.GetString("ENV_DIR")
 

--- a/internal/commands/tunnel/tunnel_down.go
+++ b/internal/commands/tunnel/tunnel_down.go
@@ -82,8 +82,6 @@ func (o *TunnelDownOptions) Run(cmd *cobra.Command) error {
 	c.Stderr = out
 	c.Dir = viper.GetString("ENV_DIR")
 
-	fmt.Println(viper.GetString("ENV_DIR"))
-
 	err := c.Run()
 	if err != nil {
 		patherr, ok := err.(*fs.PathError)

--- a/internal/commands/tunnel/tunnel_up.go
+++ b/internal/commands/tunnel/tunnel_up.go
@@ -141,13 +141,16 @@ func (o *TunnelUpOptions) Run(cmd *cobra.Command) error {
 		return fmt.Errorf("can't run tunnel up: %w", err)
 	}
 
-	c := exec.Command(
-		"ssh", "-M", "-t", "-S", "bastion.sock", "-fNT",
+	args := []string{"-M", "-t", "-S", "bastion.sock", "-fN",
 		"-o", "StrictHostKeyChecking=no",
 		fmt.Sprintf("ubuntu@%s", o.BastionHostID),
-		"-F", sshConfigPath,
-		"-i", getPrivateKey(o.PrivateKeyFile),
-	)
+		"-F", sshConfigPath}
+
+	if _, err := os.Stat(o.PrivateKeyFile); !os.IsNotExist(err) {
+		args = append(args, "-i", o.PrivateKeyFile)
+	}
+
+	c := exec.Command("ssh", args...)
 
 	c.Dir = viper.GetString("ENV_DIR")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,10 +162,11 @@ func InitConfig() {
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
-	viper.SetDefault("ENV", os.Getenv("ENV"))
-	viper.SetDefault("AWS_PROFILE", os.Getenv("AWS_PROFILE"))
-	viper.SetDefault("AWS_REGION", os.Getenv("AWS_REGION"))
-	viper.SetDefault("NAMESPACE", os.Getenv("NAMESPACE"))
+	viper.BindEnv("ENV", "ENV")
+	viper.BindEnv("AWS_PROFILE", "AWS_PROFILE")
+	viper.BindEnv("AWS_REGION", "AWS_REGION")
+	viper.BindEnv("NAMESPACE", "NAMESPACE")
+
 	// TODO: those static defaults should probably go to a separate package and/or function. Also would include image names and such.
 	viper.SetDefault("TERRAFORM_VERSION", "1.1.3")
 	viper.SetDefault("PREFER_RUNTIME", "native")

--- a/test-e2e/bastion_tunnel_test.go
+++ b/test-e2e/bastion_tunnel_test.go
@@ -16,22 +16,22 @@ func TestIzeGenEnv_bastion_tunnel(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("gen", "env")
+	stdout, stderr, err := ize.RunRaw("gen", "tfenv")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize gen env: %s", err)
+		t.Errorf("unexpected stderr output ize gen tfenv: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Generate terraform files completed") {
-		t.Errorf("No success message detected after gen env:\n%s", stdout)
+		t.Errorf("No success message detected after gen tfenv:\n%s", stdout)
 	}
 }
 
-func TestIzeDeployAll_bastion_tunnel(t *testing.T) {
+func TestIzeUpAll_bastion_tunnel(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
@@ -58,18 +58,18 @@ func TestIzeDeployAll_bastion_tunnel(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("deploy", "--auto-approve", "--prefer-runtime=docker")
+	stdout, stderr, err := ize.RunRaw("up", "--auto-approve")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize up all: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Deploy all completed!") {
-		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+		t.Errorf("No success message detected after all up:\n%s", stdout)
 	}
 }
 
@@ -139,24 +139,24 @@ func TestIzeTunnelDown(t *testing.T) {
 	}
 }
 
-func TestIzeDestroyAll_bastion_tunnel(t *testing.T) {
+func TestIzeDownAll_bastion_tunnel(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("destroy", "--auto-approve", "--prefer-runtime=docker")
+	stdout, stderr, err := ize.RunRaw("down", "--auto-approve")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize down all: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Destroy all completed!") {
-		t.Errorf("No success message detected after all destroy:\n%s", stdout)
+		t.Errorf("No success message detected after all down:\n%s", stdout)
 	}
 }

--- a/test-e2e/ecs_apps_test.go
+++ b/test-e2e/ecs_apps_test.go
@@ -268,7 +268,7 @@ func TestIzeDownAll_ecs_apps(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("dowb", "--auto-approve")
+	stdout, stderr, err := ize.RunRaw("down", "--auto-approve")
 
 	if err != nil {
 		t.Errorf("error: %s", err)

--- a/test-e2e/ecs_apps_test.go
+++ b/test-e2e/ecs_apps_test.go
@@ -31,18 +31,18 @@ func TestIzeGenEnv_ecs_apps(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("gen", "env")
+	stdout, stderr, err := ize.RunRaw("gen", "tfenv")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize gen tfenv: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Generate terraform files completed") {
-		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+		t.Errorf("No success message detected after gen tfenv:\n%s", stdout)
 	}
 }
 
@@ -145,7 +145,7 @@ func TestIzeSecretsPushSquibby(t *testing.T) {
 	}
 }
 
-func TestIzeDeployAll_ecs_apps(t *testing.T) {
+func TestIzeUpAll_ecs_apps(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
@@ -172,18 +172,18 @@ func TestIzeDeployAll_ecs_apps(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("up", "--auto-approve", "--prefer-runtime=docker")
+	stdout, stderr, err := ize.RunRaw("up", "--auto-approve")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize up all: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Deploy all completed!") {
-		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+		t.Errorf("No success message detected after all up:\n%s", stdout)
 	}
 }
 
@@ -201,11 +201,11 @@ func TestIzeExecGoblin(t *testing.T) {
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize exec goblin: %s", err)
 	}
 
 	if !strings.Contains(stdout, "goblin") {
-		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+		t.Errorf("No success message detected after exec goblin:\n%s", stdout)
 	}
 }
 
@@ -261,24 +261,24 @@ func randInt(min int, max int) int {
 	return min + rand.Intn(max-min)
 }
 
-func TestIzeDestroyAll_ecs_apps(t *testing.T) {
+func TestIzeDownAll_ecs_apps(t *testing.T) {
 	if examplesRootDir == "" {
 		t.Fatalf("Missing required environment variable IZE_PROJECT_TEMPLATE_PATH")
 	}
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("destroy", "--auto-approve", "--prefer-runtime=docker")
+	stdout, stderr, err := ize.RunRaw("dowb", "--auto-approve")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize dowb all: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Destroy all completed!") {
-		t.Errorf("No success message detected after all destroy:\n%s", stdout)
+		t.Errorf("No success message detected after down:\n%s", stdout)
 	}
 }

--- a/test-e2e/terraform_test.go
+++ b/test-e2e/terraform_test.go
@@ -36,18 +36,18 @@ func TestIzeTerraformInit(t *testing.T) {
 
 	ize := NewBinary(t, izeBinary, examplesRootDir)
 
-	stdout, stderr, err := ize.RunRaw("gen", "env")
+	stdout, stderr, err := ize.RunRaw("gen", "tfenv")
 
 	if err != nil {
 		t.Errorf("error: %s", err)
 	}
 
 	if stderr != "" {
-		t.Errorf("unexpected stderr output ize deploy all: %s", err)
+		t.Errorf("unexpected stderr output ize gen tfenv: %s", err)
 	}
 
 	if !strings.Contains(stdout, "Generate terraform files completed") {
-		t.Errorf("No success message detected after all deploy:\n%s", stdout)
+		t.Errorf("No success message detected after gen tfenv:\n%s", stdout)
 	}
 
 	stdout, stderr, err = ize.RunRaw("terraform", "init")


### PR DESCRIPTION
## Changelog:
- fix overwriting `ENV` environment variable by env in ize.toml
- set `max-parallel` value to 1
- update test run command
- fix `IZE_EXAMPLES_PATH` environment variable in bastion tunnel test
- remove `ENV` variable from config file
- update ssh command building in `tunnel` and `tunnel up` commands
- update `terraform-switcher` version
- rename `env` command to `tfenv` command in tests
- rename `deploy` command to `up` command in tests
- rename `destroy` command to `down` command in tests
- update tests to to non-docker runtime

## Tests:
#### fix overwriting `ENV`
[![asciicast](https://asciinema.org/a/WaRdT7NU15yv3uHyeU6kc0elA.svg)](https://asciinema.org/a/WaRdT7NU15yv3uHyeU6kc0elA)
