### PR TITLE
IZE-376 fix apps urls

### DIFF
--- a/test-e2e/ecs_apps_test.go
+++ b/test-e2e/ecs_apps_test.go
@@ -210,7 +210,7 @@ func TestIzeExecGoblin(t *testing.T) {
 }
 
 func TestCheckSecretsSquibby(t *testing.T) {
-	url := "http://squibby.testnut.examples.ize.sh/"
+	url := fmt.Sprintf("http://squibby.%s.examples.ize.sh/", os.Getenv("ENV"))
 
 	for i := 0; i < 10; i++ {
 		resp, err := http.Get(url)
@@ -234,7 +234,7 @@ func TestCheckSecretsSquibby(t *testing.T) {
 }
 
 func TestCheckSecretsGoblin(t *testing.T) {
-	url := "http://goblin.testnut.examples.ize.sh/"
+	url := fmt.Sprintf("http://goblin.%s.examples.ize.sh/", os.Getenv("ENV"))
 
 	for i := 0; i < 10; i++ {
 		resp, err := http.Get(url)


### PR DESCRIPTION
## Changelog:
- fix apps urls

## Test:
```
=== RUN   TestIzeGenEnv_ecs_apps
--- PASS: TestIzeGenEnv_ecs_apps (2.95s)
=== RUN   TestIzeSecretsPushGoblin
--- PASS: TestIzeSecretsPushGoblin (5.68s)
=== RUN   TestIzeSecretsPushSquibby
--- PASS: TestIzeSecretsPushSquibby (5.69s)
=== RUN   TestIzeUpAll_ecs_apps
--- PASS: TestIzeUpAll_ecs_apps (359.04s)
=== RUN   TestIzeExecGoblin
--- PASS: TestIzeExecGoblin (6.54s)
=== RUN   TestCheckSecretsSquibby
--- PASS: TestCheckSecretsSquibby (1.81s)
=== RUN   TestCheckSecretsGoblin
    ecs_apps_test.go:257: The expected string was not found in the response: http://squibby.test-ecs-apps.examples.ize.sh/
--- FAIL: TestCheckSecretsGoblin (52.73s)
=== RUN   TestIzeDownAll_ecs_apps
--- PASS: TestIzeDownAll_ecs_apps (392.16s)
FAIL
FAIL    github.com/hazelops/ize/test-e2e        826.608s
FAIL
```