### PR TITLE
IZE-416 IZE-418 IZE-419 able to read tag env var in addition to ize tag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -168,6 +168,7 @@ func InitConfig() {
 	viper.AutomaticEnv()
 
 	viper.BindEnv("ENV", "ENV")
+	viper.BindEnv("TAG", "TAG")
 	viper.BindEnv("AWS_PROFILE", "AWS_PROFILE")
 	viper.BindEnv("AWS_REGION", "AWS_REGION")
 	viper.BindEnv("NAMESPACE", "NAMESPACE")

--- a/internal/schema/ize-spec.json
+++ b/internal/schema/ize-spec.json
@@ -296,13 +296,13 @@
         }
     },
     "required": [
+        "env",
         "aws_profile",
         "aws_region",
-        "env",
+        "namespace",
         "env_dir",
         "home",
         "infra_dir",
-        "namespace",
         "prefer_runtime",
         "root_dir"
     ],


### PR DESCRIPTION
## Changelog:
- bind `TAG` env to `IZE_TAG` env
- change the order of required parameters in json shema
- move settings tag parameter after init config


## Test:
[![asciicast](https://asciinema.org/a/UWXi6PM7UtC8mlAj1EBmFsibJ.svg)](https://asciinema.org/a/UWXi6PM7UtC8mlAj1EBmFsibJ)