### PR TITLE
IZE-415 add `container-name` flag to `console` and `exec` commands

### DIFF
--- a/internal/commands/console/console.go
+++ b/internal/commands/console/console.go
@@ -13,11 +13,12 @@ import (
 )
 
 type Options struct {
-	Config       *config.Project
-	AppName      string
-	EcsCluster   string
-	Task         string
-	CustomPrompt bool
+	Config        *config.Project
+	AppName       string
+	EcsCluster    string
+	Task          string
+	CustomPrompt  bool
+	ContainerName string
 }
 
 func NewConsoleFlags() *Options {
@@ -54,6 +55,7 @@ func NewCmdConsole() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&o.EcsCluster, "ecs-cluster", "", "set ECS cluster name")
+	cmd.Flags().StringVar(&o.ContainerName, "container-name", "", "set container name")
 	cmd.Flags().StringVar(&o.Task, "task", "", "set task id")
 	cmd.Flags().BoolVar(&o.CustomPrompt, "custom-prompt", false, "enable custom prompt in the console")
 
@@ -80,6 +82,10 @@ func (o *Options) Complete(cmd *cobra.Command) error {
 	}
 
 	o.AppName = cmd.Flags().Args()[0]
+
+	if len(o.ContainerName) == 0 {
+		o.ContainerName = o.AppName
+	}
 
 	return nil
 }
@@ -145,7 +151,7 @@ func (o *Options) Run() error {
 	}
 
 	out, err := ecsSvc.ExecuteCommand(&ecs.ExecuteCommandInput{
-		Container:   &o.AppName,
+		Container:   &o.ContainerName,
 		Interactive: aws.Bool(true),
 		Cluster:     &o.EcsCluster,
 		Task:        &o.Task,
@@ -163,7 +169,7 @@ func (o *Options) Run() error {
 	s.Success()
 
 	ssmCmd := ssmsession.NewSSMPluginCommand(o.Config.AwsRegion)
-	ssmCmd.Start((out.Session))
+	ssmCmd.Start(out.Session)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/exec/exec.go
+++ b/internal/commands/exec/exec.go
@@ -16,11 +16,12 @@ import (
 )
 
 type ExecOptions struct {
-	Config     *config.Project
-	AppName    string
-	EcsCluster string
-	Command    string
-	Task       string
+	Config        *config.Project
+	AppName       string
+	EcsCluster    string
+	Command       string
+	Task          string
+	ContainerName string
 }
 
 var execExample = templates.Examples(`
@@ -65,6 +66,7 @@ func NewCmdExec() *cobra.Command {
 
 	cmd.Flags().StringVar(&o.EcsCluster, "ecs-cluster", "", "set ECS cluster name")
 	cmd.Flags().StringVar(&o.Task, "task", "", "set task id")
+	cmd.Flags().StringVar(&o.ContainerName, "container-name", "", "set container name")
 
 	return cmd
 }
@@ -86,6 +88,10 @@ func (o *ExecOptions) Complete(cmd *cobra.Command, args []string, argsLenAtDash 
 
 	o.AppName = cmd.Flags().Args()[0]
 
+	if len(o.ContainerName) == 0 {
+		o.ContainerName = o.AppName
+	}
+
 	o.Command = strings.Join(args[argsLenAtDash:], " ")
 
 	return nil
@@ -103,6 +109,11 @@ func (o *ExecOptions) Validate() error {
 	if len(o.AppName) == 0 {
 		return fmt.Errorf("can't validate: app name must be specified")
 	}
+
+	if len(o.Command) == 0 {
+		return fmt.Errorf("can't validate: command must be specified")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Changelog:
- add `container-name` flag to `console` and `exec` commands

## Test
[![asciicast](https://asciinema.org/a/BcGhNWi1UltRwUSDhMhUYZJWr.svg)](https://asciinema.org/a/BcGhNWi1UltRwUSDhMhUYZJWr)