### PR TITLE
IZE-479 add default terraform bucket name to create backend.tf

### DIFF
--- a/internal/commands/up/up.go
+++ b/internal/commands/up/up.go
@@ -359,7 +359,7 @@ func deployInfra(ui terminal.UI, config *config.Project, skipGen bool) error {
 		if !checkFileExists(filepath.Join(config.EnvDir, "backend.tf")) || !checkFileExists(filepath.Join(config.EnvDir, "terraform.tfvars")) {
 			err := gen.GenerateTerraformFiles(
 				config,
-				"",
+				fmt.Sprintf("%s-tf-state", config.Namespace),
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
## Changelog:
- add default terraform bucket name to create backend.tf

## Test:
[![asciicast](https://asciinema.org/a/p1XEhXEnmwtV0q36g9g4BPZyF.svg)](https://asciinema.org/a/p1XEhXEnmwtV0q36g9g4BPZyF)