### PR TITLE
IZE-508: Fix typo

### DIFF
--- a/internal/manager/serverless/native.go
+++ b/internal/manager/serverless/native.go
@@ -128,7 +128,7 @@ func (sls *Manager) runCreateDomain(w io.Writer) error {
 				--region %s \
 				--profile %s \
 				--stage %s`,
-		nvmDir, sls.App.Name, sls.App.AwsRegion,
+		nvmDir, sls.App.NodeVersion, sls.App.AwsRegion,
 		sls.App.AwsProfile, sls.Project.Env)
 
 	cmd := exec.Command("bash", "-c", command)


### PR DESCRIPTION
This fixes a typo where node version was not used.