### PR TITLE
IZE-585 IZE-577 IZE-580 invalid ize exec command not handled

### DIFF
--- a/internal/commands/doc.go
+++ b/internal/commands/doc.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"os"
 )
 
 func NewCmdDoc() *cobra.Command {
@@ -14,8 +15,12 @@ func NewCmdDoc() *cobra.Command {
 		Long:                  "Create docs with ize commands description",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			err := os.MkdirAll("./website/commands", 0777)
+			if err != nil {
+				return err
+			}
 
-			err := doc.GenMarkdownTree(cmd.Root(), "./commands")
+			err = doc.GenMarkdownTree(cmd.Root(), "./website/commands")
 			if err != nil {
 				return err
 			}

--- a/internal/commands/exec.go
+++ b/internal/commands/exec.go
@@ -2,25 +2,24 @@ package commands
 
 import (
 	"fmt"
-	"github.com/hazelops/ize/internal/requirements"
-	"strings"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/hazelops/ize/internal/config"
+	"github.com/hazelops/ize/internal/requirements"
 	"github.com/hazelops/ize/pkg/ssmsession"
 	"github.com/hazelops/ize/pkg/templates"
 	"github.com/pterm/pterm"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 type ExecOptions struct {
 	Config        *config.Project
 	AppName       string
 	EcsCluster    string
-	Command       string
+	Command       []string
 	Task          string
 	ContainerName string
 }
@@ -90,7 +89,9 @@ func (o *ExecOptions) Complete(cmd *cobra.Command, args []string, argsLenAtDash 
 		o.ContainerName = o.AppName
 	}
 
-	o.Command = strings.Join(args[argsLenAtDash:], " ")
+	if argsLenAtDash > -1 {
+		o.Command = args[argsLenAtDash:]
+	}
 
 	return nil
 }
@@ -109,7 +110,7 @@ func (o *ExecOptions) Validate() error {
 	}
 
 	if len(o.Command) == 0 {
-		return fmt.Errorf("can't validate: command must be specified")
+		return fmt.Errorf("can't validate: you must specify at least one command for the container")
 	}
 
 	return nil
@@ -156,7 +157,7 @@ func (o *ExecOptions) Run() error {
 		Interactive: aws.Bool(true),
 		Cluster:     &o.EcsCluster,
 		Task:        &o.Task,
-		Command:     aws.String(o.Command),
+		Command:     aws.String(strings.Join(o.Command, " ")),
 	})
 	if aerr, ok := err.(awserr.Error); ok {
 		switch aerr.Code() {

--- a/internal/commands/ize.go
+++ b/internal/commands/ize.go
@@ -119,14 +119,14 @@ func Execute() {
 }
 
 func getConfig(cfg *config.Project) {
-	if !(slices.Contains(os.Args, "aws-profile") ||
-		slices.Contains(os.Args, "doc") ||
-		slices.Contains(os.Args, "completion") ||
-		slices.Contains(os.Args, "version") ||
-		slices.Contains(os.Args, "init") ||
-		slices.Contains(os.Args, "validate") ||
-		slices.Contains(os.Args, "config")) ||
-		slices.Contains(os.Args, "terraform") {
+	if slices.Contains(os.Args, "terraform") ||
+		!(slices.Contains(os.Args, "aws-profile") ||
+			slices.Contains(os.Args, "doc") ||
+			slices.Contains(os.Args, "completion") ||
+			slices.Contains(os.Args, "version") ||
+			slices.Contains(os.Args, "init") ||
+			slices.Contains(os.Args, "validate") ||
+			slices.Contains(os.Args, "config")) {
 		err := cfg.GetConfig()
 		if err != nil {
 			pterm.Error.Println(err)


### PR DESCRIPTION
## Changelog:
- fixed handling of missing commands
- fixed detection of env parameter in 'ize terraform` command
- fixed command documentation generation

## Tests:
[![asciicast](https://asciinema.org/a/4wmGgisJIJVAwlmLgyYwhTUnt.svg)](https://asciinema.org/a/4wmGgisJIJVAwlmLgyYwhTUnt)

[![asciicast](https://asciinema.org/a/Ob3qPhGsyhPNlzwORZvCnw6KW.svg)](https://asciinema.org/a/Ob3qPhGsyhPNlzwORZvCnw6KW)

[![asciicast](https://asciinema.org/a/oBkLr4pcqri0RNv8lmFNgdfmN.svg)](https://asciinema.org/a/oBkLr4pcqri0RNv8lmFNgdfmN)