### PR TITLE
IZE-599 ize infra down doesnt run terraform init

### DIFF
--- a/internal/commands/down.go
+++ b/internal/commands/down.go
@@ -273,9 +273,9 @@ func destroyInfra(state string, config *config.Project, skipGen bool, ui termina
 
 	switch config.PreferRuntime {
 	case "docker":
-		tf = terraform.NewDockerTerraform(state, []string{"destroy", "-auto-approve"}, env, nil, config)
+		tf = terraform.NewDockerTerraform(state, []string{"init", "-input=true"}, env, nil, config)
 	case "native":
-		tf = terraform.NewLocalTerraform(state, []string{"destroy", "-auto-approve"}, env, nil, config)
+		tf = terraform.NewLocalTerraform(state, []string{"init", "-input=true"}, env, nil, config)
 		err = tf.Prepare()
 		if err != nil {
 			return fmt.Errorf("can't destroy infra: %w", err)
@@ -284,11 +284,21 @@ func destroyInfra(state string, config *config.Project, skipGen bool, ui termina
 		return fmt.Errorf("can't supported %s runtime", config.PreferRuntime)
 	}
 
-	ui.Output("Running terraform destroy...", terminal.WithHeaderStyle())
+	ui.Output("Execution terraform init...", terminal.WithHeaderStyle())
 
 	err = tf.RunUI(ui)
 	if err != nil {
 		return err
+	}
+
+	//terraform destroy run options
+	tf.NewCmd([]string{"destroy", "-auto-approve"})
+
+	ui.Output("Execution terraform destroy...", terminal.WithHeaderStyle())
+
+	err = tf.RunUI(ui)
+	if err != nil {
+		return fmt.Errorf("can't deploy infra: %w", err)
 	}
 
 	ui.Output("Terraform destroy completed!\n", terminal.WithSuccessStyle())

--- a/internal/commands/down_infra.go
+++ b/internal/commands/down_infra.go
@@ -120,7 +120,7 @@ func (o *DownInfraOptions) Run() error {
 		}
 	}
 
-	err := manager.InReversDependencyOrder(aws.BackgroundContext(), o.Config.GetApps(), func(c context.Context, name string) error {
+	err := manager.InReversDependencyOrder(aws.BackgroundContext(), o.Config.GetStates(), func(c context.Context, name string) error {
 		return destroyInfra(name, o.Config, o.SkipGen, ui)
 	})
 	if err != nil {


### PR DESCRIPTION
## Changelog:
added call `terraform init` before `terraform destroy` in `ize down`/`ize down infra` commands

## Test:
[![asciicast](https://asciinema.org/a/AVW2OSIUZ6bl3oJMR70oFsXAk.svg)](https://asciinema.org/a/AVW2OSIUZ6bl3oJMR70oFsXAk)