### PR TITLE
IZE-598 added generation of markdown files with IZE specification

### DIFF
--- a/internal/commands/doc.go
+++ b/internal/commands/doc.go
@@ -1,10 +1,16 @@
 package commands
 
 import (
+	"github.com/hazelops/ize/internal/schema"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
 )
 
 func NewCmdDoc() *cobra.Command {
@@ -25,6 +31,26 @@ func NewCmdDoc() *cobra.Command {
 				return err
 			}
 
+			sections := []string{"main", "terraform", "ecs", "alias", "serverless", "tunnel"}
+
+			err = os.MkdirAll("./website/schema", 0777)
+			if err != nil {
+				return err
+			}
+
+			t := template.New("schema")
+			t, err = t.Parse(sectionTmpl)
+			if err != nil {
+				return err
+			}
+
+			for _, s := range sections {
+				err := generateSection(s, t)
+				if err != nil {
+					return err
+				}
+			}
+
 			pterm.Success.Printfln("Docs generated")
 
 			return nil
@@ -33,3 +59,42 @@ func NewCmdDoc() *cobra.Command {
 
 	return cmd
 }
+
+func generateSection(name string, t *template.Template) error {
+	s := schema.GetSchema()
+	filename := "README.md"
+	if name != "main" {
+		filename = strings.ToUpper(name) + ".md"
+		s = schema.GetSchema()[name].Items
+	}
+	f, err := os.Create(filepath.Join(".", "website", "schema", filename))
+	if err != nil {
+		return err
+	}
+
+	err = t.Execute(f, Section{
+		Name:  cases.Title(language.Und).String(name),
+		Items: s,
+	})
+	if err != nil {
+		return err
+	}
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type Section struct {
+	Name string
+	schema.Items
+}
+
+var sectionTmpl = `# {{.Name}} Section
+| Parameter | Required | Description |
+| --- | --- | --- |
+{{range $k, $v := .Items}}| {{$k}} | {{if $v.Required}}yes{{else}}no {{end}}| {{$v.Description}} |
+{{end}}
+`

--- a/internal/commands/doc.go
+++ b/internal/commands/doc.go
@@ -95,6 +95,6 @@ type Section struct {
 var sectionTmpl = `# {{.Name}} Section
 | Parameter | Required | Description |
 | --- | --- | --- |
-{{range $k, $v := .Items}}| {{$k}} | {{if $v.Required}}yes{{else}}no {{end}}| {{$v.Description}} |
+{{range $k, $v := .Items}}| {{$k}} | {{if $v.Required}}yes{{else}}no{{end}}| {{$v.Description}} |
 {{end}}
 `

--- a/internal/schema/ize-spec.json
+++ b/internal/schema/ize-spec.json
@@ -119,7 +119,7 @@
                     "$ref": "#/definitions/app"
                 }
             },
-            "description": "Apps configuration.",
+            "description": "(deprecated) Apps configuration.",
             "additionalProperties": false
         },
         "ecs": {
@@ -205,7 +205,7 @@
                             "description": "(optional) Terraform-specific AWS profile (optional) can be specified here (but normally it should be inherited from a global AWS_PROFILE)."
                         }
                     },
-                    "description": "Infrastructure configuration.",
+                    "description": "(deprecated) Infrastructure configuration.",
                     "additionalProperties": false
                 },
                 "tunnel": {
@@ -308,7 +308,7 @@
                     "description": "(optional) expresses startup and shutdown dependencies between apps"
                 }
             },
-            "description": "App configuration.",
+            "description": "(deprecated) App configuration.",
             "additionalProperties": false
         },
         "ecs": {


### PR DESCRIPTION
## Change:
added generation of markdown files with IZE specification

## Test:
[![asciicast](https://asciinema.org/a/RiV0MZx8pg51Fbnh2D3Zbuty8.svg)](https://asciinema.org/a/RiV0MZx8pg51Fbnh2D3Zbuty8)

### Ecs Section
| Parameter | Required | Description |
| --- | --- | --- |
| aws_profile | no | (optional) ECS-specific AWS profile (optional) can be specified here (but normally it should be inherited from a global AWS_PROFILE). |
| aws_region | no | (optional) ECS-specific AWS Region of this environment should be specified here. Normally global AWS_REGION is used. |
| cluster | no | (optional) ECS cluster can be specified here. By default it's derived from env & namespace |
| depends_on | no | (optional) expresses startup and shutdown dependencies between apps |
| docker_registry | no | (optional) Docker registry can be set here. By default it uses ECR repo with the name of the service. |
| icon | no | (optional) set icon |
| image | no | (optional) Docker image can be specified here. By default it's derived from the app name. |
| path | no | (optional) Path to ecs app folder can be specified here. By default it's derived from apps path and app name. |
| skip_deploy | no | (optional) skip deploy app. |
| task_definition_revision | no | (optional) Task definition revision can be specified here. By default latest revision is used to perform a deployment. Normally this parameter can be used via cli during specific deployment needs. |
| timeout | no | (optional) ECS deployment timeout can be specified here. |
| unsafe | no | (optional) Enables unsafe mode that increases deploy time on a cost of shorter healthcheck. |



### Main Section
| Parameter | Required | Description |
| --- | --- | --- |
| alias | no | (optional) Alias mode can be enabled here. This can be used to combine various apps via depends_on parameter. |
| apps_path | no | (optional) Path to apps directory can be set. By default apps are searched in 'apps' and 'projects' directories. This is needed in case your repo structure is not purely ize-structured (let's say you have 'src' repo in your dotnet app, as an example) |
| aws_profile | yes| (optional) AWS Profile can be specified here (but normally it's specified via AWS_PROFILE env var) |
| aws_region | yes| (required) AWS Region of this environment should be specified here. Can be overridden by AWS_PROFILE env var or --aws-region flag. |
| config_file | no | (optional) Path to ize.toml config file can be specified, but normally it's read from the environment's directory automatically. |
| custom_prompt | no | (optional) Custom prompt can be enabled here for all console connections. Default: false. |
| docker_registry | no | (optional) Docker registry can be set here. By default it uses ECR repo with the name of the service. |
| ecs | no | Ecs apps configuration. |
| env | yes| (optional) Environment name can be specified here. Normally it should be passed via `ENV` variable or --env flag. |
| env_dir | yes| (optional) Environment directory can be specified here. Normally it's calculated automatically based on the directory structure convention. |
| home | yes| (optional) User home directory can be specified here. Normally $HOME is used. |
| infra | no | Infrastructure configuration. |
| ize_dir | yes| (optional) Ize directory can be specified here. Normally it's assumed to be .infra or .ize in the current repo. |
| log_level | no | (optional) Log level can be specified here. Possible levels: info, debug, trace, panic, warn, error, fatal(default). Can be overridden via IZE_LOG_LEVEL env var or via --log-level flag. |
| namespace | yes| (required) Namespace of the project can be specified here. It is used as a base for all naming. It can be overridden by NAMESPACE env var or --namespace flag. |
| plain_text | no | (optional) Plain text output can be enabled here. Default is false. Can be overridden by IZE_PLAIN_TEXT env var or --plain-text flag. |
| prefer_runtime | yes| (optional) Prefer a specific runtime. (native or docker) (default 'native') |
| root_dir | yes| (optional) Project directory can be set here. By default it's the current directory, but in case you prefer to run ize from the outside of repo it may be useful (uncommon). |
| serverless | no | Serverless apps configuration. |
| tag | no | (optional) Tag can be set statically. Normally it is being constructed automatically based on the git revision. |
| terraform | no | Terraform configuration. |
| terraform_version | no | (optional) Terraform version can be set here. 1.1.3 by default |
| tf_log | no | (optional) Terraform TF_LOG can be set here.  Can be TRACE, DEBUG, INFO, WARN or ERROR. |
| tf_log_path | no | (optional) TF_LOG_PATH can be set here. |
| tunnel | no | Tunnel configuration. |

