### PR TITLE
IZE-487 added display of possible properties when ize.toml has invalid syntax

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -33,7 +33,18 @@ func Validate(config map[string]interface{}) error {
 		} else {
 			i = strings.ReplaceAll(i[2:], "/", ".")
 		}
-		return fmt.Errorf("%s in %s of config file (or environment variables)", m, i)
+		errMsg := fmt.Sprintf("%s in %s of config file (or environment variables)", m, i)
+		if strings.Contains(errMsg, "additionalProperties") {
+			errMsg += ". The following options are available:\n"
+			properties := GetSchema()
+			if i != "root" {
+				properties = properties[strings.Split(i, ".")[0]].Items
+			}
+			for k := range properties {
+				errMsg += fmt.Sprintf("- %s\n", k)
+			}
+		}
+		return fmt.Errorf(errMsg)
 	}
 
 	return nil


### PR DESCRIPTION
## Change:
added display of possible properties when ize.toml has invalid syntax

## Test:
[![asciicast](https://asciinema.org/a/RUSXCH2y0mGNjaAvRAhc7w9j8.svg)](https://asciinema.org/a/RUSXCH2y0mGNjaAvRAhc7w9j8)