### PR TITLE
IZE-649 expanded forwarding config is not valid

### DIFF
--- a/internal/commands/tunnel_up.go
+++ b/internal/commands/tunnel_up.go
@@ -498,7 +498,11 @@ func writeSSHConfigFromSSM(wr *SSMWrapper, env string, dir string) (string, []st
 
 	hosts := getHosts(sshConfig)
 	if len(hosts) == 0 {
-		return "", []string{}, fmt.Errorf("can't write SSH config: forwarding config is not valid")
+		errMsg := "can't write SSH config: forwarding config is not valid"
+		if logrus.GetLevel() == logrus.DebugLevel {
+			errMsg += fmt.Sprintf(". Config in SSM: \n%s", sshConfig)
+		}
+		return "", []string{}, fmt.Errorf(errMsg)
 	}
 
 	bastionHostID = to.BastionInstanceID.Value


### PR DESCRIPTION
## Change:
showed the full ssh config when it is invalid

## Test:
[![asciicast](https://asciinema.org/a/Gvf137DsjdVcMQf04nKifuuug.svg)](https://asciinema.org/a/Gvf137DsjdVcMQf04nKifuuug)
