### PR TITLE
IZE-722 passed aws region via an env var for up tunnel

### DIFF
--- a/internal/commands/tunnel_up.go
+++ b/internal/commands/tunnel_up.go
@@ -268,6 +268,7 @@ func (o *TunnelUpOptions) runSSH(args []string) error {
 	c := exec.Command("ssh", args...)
 
 	c.Dir = o.Config.EnvDir
+	os.Setenv("AWS_REGION", o.Config.AwsRegion)
 
 	runner := term.New(term.WithStdin(os.Stdin))
 	_, _, code, err := runner.Run(c)


### PR DESCRIPTION
## Change:
passed aws region via an env var for up tunnel

## Test:
![demo](https://user-images.githubusercontent.com/47272597/202292681-2512e56e-f917-4362-9188-5a6b3cf2549f.gif)
